### PR TITLE
Allow any value that is a kind of the expected type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,3 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'rake', '~>0.9.2'
-
-gem 'assert-mocha', :git => "git@github.com:jcredding/assert-mocha.git"

--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -11,7 +11,7 @@ module NsOptions
       self.rules = rules
       self.value = rules[:default]
     end
-    
+
     def value
       if self.type_class == NsOptions::Option::Boolean
         @value and @value.actual
@@ -21,17 +21,17 @@ module NsOptions
     end
 
     def value=(new_value)
-      @value = if (new_value.class == self.type_class) || new_value.nil?
+      @value = if (new_value.kind_of?(self.type_class)) || new_value.nil?
         new_value
       else
         self.coerce(new_value)
       end
     end
-    
+
     def is_set?
       self.value.respond_to?(:is_set?) ? self.value.is_set? : !self.value.nil?
     end
-    
+
     def required?
       !!self.rules[:required] || !!self.rules[:require]
     end

--- a/ns-options.gemspec
+++ b/ns-options.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = NsOptions::VERSION
 
-  gem.add_development_dependency("assert",        ["~>0.6.0"])
-  gem.add_development_dependency("assert-mocha",  ["~>0.1.0"])
+  gem.add_development_dependency("assert",        ["~>0.6"])
+  gem.add_development_dependency("assert-mocha",  ["~>0.1"])
 end

--- a/test/unit/ns-options/option_test.rb
+++ b/test/unit/ns-options/option_test.rb
@@ -187,5 +187,34 @@ class NsOptions::Option
       assert_equal String, subject.type_class
     end
   end
+  
+  class WithAValueOfTheSameClassTest < BaseTest
+    desc "with a value of the same class"
+    setup do
+      @class = Class.new
+      @option = NsOptions::Option.new(:something, @class)
+    end
+    
+    should "use the object passed to it instead of creating a new one" do
+      value = @class.new
+      @option.value = value
+      assert_same value, @option.value
+    end
+  end
+  
+  class WithAValueKindOfTest < BaseTest
+    desc "with a value is a kind of the class"
+    setup do
+      @class = Class.new
+      @child_class = Class.new(@class)
+      @option = NsOptions::Option.new(:something, @class)
+    end
+    
+    should "use the object passed to it instead of creating a new one" do
+      value = @child_class.new
+      @option.value = value
+      assert_same value, @option.value
+    end
+  end
 
 end


### PR DESCRIPTION
@kelredd this loosens the restriction that a value be of the exact type of what the option was setup with. Now it would simply have to be a kind of the class it was setup with.
