### PR TITLE
allow for just including on NsOptions

### DIFF
--- a/lib/ns-options.rb
+++ b/lib/ns-options.rb
@@ -6,4 +6,9 @@ module NsOptions
   autoload :Option,         'ns-options/option'
   autoload :Options,        'ns-options/options'
   autoload :VERSION,        'ns-options/version'
+
+  def self.included(receiver)
+    receiver.send(:include, HasOptions)
+  end
+
 end

--- a/test/support/app.rb
+++ b/test/support/app.rb
@@ -1,5 +1,8 @@
 module App
-  include NsOptions::HasOptions
+
+  # mixin on just the top-level NsOptions variant
+  include NsOptions
+
   options(:settings, "settings:app") do
     option :root,   Pathname
     option :stage

--- a/test/support/user.rb
+++ b/test/support/user.rb
@@ -1,5 +1,8 @@
 class User
+
+  # mixin using the specific HasOptions variant
   include NsOptions::HasOptions
+
   options(:preferences, 'user-preferences') do
     option :home_url
     option :show_messages,  NsOptions::Option::Boolean, :require => true


### PR DESCRIPTION
- NsOptions, on included, includes HasOptions for you
- I just changed the App support module to include this way and all tests passed so I figure this is good

Closes #3

@jcredding - merge if you are cool.
