### PR TITLE
Default an option's type class to Object instead of String

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,7 +34,7 @@ App.settings.stage = "development"
 App.settings.stage # => "development"
 ```
 
-Because the `root` option specified `Pathname` as it's type, the option will always return an instance of `Pathname`. Since the `stage` option did not specify a type, it defaulted to a `String`. You can define you're own type classes as well and use them:
+Because the `root` option specified `Pathname` as it's type, the option will always return an instance of `Pathname`. Since the `stage` option did not specify a type, it defaulted to an `Object` which allows it to accept any value. You can define you're own type classes as well and use them:
 
 ```ruby
 class Stage < String

--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -5,7 +5,7 @@ module NsOptions
 
     attr_accessor :name, :value, :type_class, :rules
 
-    def initialize(name, type_class, rules = {})
+    def initialize(name, type_class = nil, rules = {})
       self.name = name.to_s
       self.type_class = self.usable_type_class(type_class)
       self.rules = rules
@@ -61,7 +61,7 @@ module NsOptions
       elsif [ TrueClass, FalseClass ].include?(type_class)
         NsOptions::Option::Boolean
       else
-        (type_class || String)
+        (type_class || Object)
       end
     end
 

--- a/test/unit/ns-options/namespace_test.rb
+++ b/test/unit/ns-options/namespace_test.rb
@@ -50,9 +50,9 @@ class NsOptions::Namespace
     end
     subject{ @namespace }
 
-    should "default the type to String" do
+    should "default the type to Object" do
       assert(option = subject.options[@name])
-      assert_equal String, option.type_class
+      assert_equal Object, option.type_class
     end
   end
 

--- a/test/unit/ns-options/option_test.rb
+++ b/test/unit/ns-options/option_test.rb
@@ -183,8 +183,8 @@ class NsOptions::Option
     end
     subject{ @option }
 
-    should "have default it to String" do
-      assert_equal String, subject.type_class
+    should "have default it to Object" do
+      assert_equal Object, subject.type_class
     end
   end
   

--- a/test/unit/ns-options/options_test.rb
+++ b/test/unit/ns-options/options_test.rb
@@ -44,9 +44,9 @@ class NsOptions::Options
     end
     subject{ @options }
 
-    should "have added a string option on itself when adding :my_string" do
+    should "have added a object option on itself when adding :my_string" do
       assert(option = subject[:my_string])
-      assert_equal String, option.type_class
+      assert_equal Object, option.type_class
       assert_equal({}, option.rules)
     end
     should "have added an integer option on itself when adding :my_integer" do


### PR DESCRIPTION
Whenever a type class is not provided, instead of `String`, `Object` will be used. This combined with an option's `kind_of?` check basically allows the option to accept any value with no problems.

@kelredd - check it out and let me know if you see anything wrong with it
