### PR TITLE
Handle nil values better

### DIFF
--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -60,6 +60,8 @@ module NsOptions
         Integer
       elsif [ TrueClass, FalseClass ].include?(type_class)
         NsOptions::Option::Boolean
+      elsif type_class == NilClass
+        Object
       else
         (type_class || String)
       end

--- a/test/unit/ns-options/namespace_test.rb
+++ b/test/unit/ns-options/namespace_test.rb
@@ -184,6 +184,7 @@ class NsOptions::Namespace
         @namespace.something_not_defined = "you know it"
         @namespace.another_not_defined = true
         @namespace.even_more_not_defined = 12
+        @namespace.just_one_more_not_defined = nil
       end
 
       should "have defined the accessors and added the option" do
@@ -197,6 +198,9 @@ class NsOptions::Namespace
         assert_equal String, subject.options[:something_not_defined].type_class
         assert_equal Integer, subject.options[:even_more_not_defined].type_class
         assert_equal NsOptions::Option::Boolean, subject.options[:another_not_defined].type_class
+      end
+      should "use Object for the type class when the value is nil" do
+        assert_equal Object, subject.options[:just_one_more_not_defined].type_class
       end
     end
   end

--- a/test/unit/ns-options/option_test.rb
+++ b/test/unit/ns-options/option_test.rb
@@ -27,6 +27,10 @@ class NsOptions::Option
     should "return true with a call to #required?" do
       assert_equal true, subject.required?
     end
+    should "allow setting the value to nil" do
+      subject.value = nil
+      assert_nil subject.value
+    end
   end
 
   class IsSetTest < BaseTest
@@ -176,6 +180,18 @@ class NsOptions::Option
     end
   end
 
+  class WithNilClassTest < BaseTest
+    desc "with a NilClass as a type class (happens with dynamic writers)"
+    setup do
+      @nil_option = NsOptions::Option.new(:something, NilClass)
+    end
+    subject{ @nil_option }
+
+    should "have used Object for their type class" do
+      assert_equal Object, @nil_option.type_class
+    end
+  end
+
   class WithoutTypeClassTest < BaseTest
     desc "without a type class provided"
     setup do
@@ -187,21 +203,21 @@ class NsOptions::Option
       assert_equal String, subject.type_class
     end
   end
-  
+
   class WithAValueOfTheSameClassTest < BaseTest
     desc "with a value of the same class"
     setup do
       @class = Class.new
       @option = NsOptions::Option.new(:something, @class)
     end
-    
+
     should "use the object passed to it instead of creating a new one" do
       value = @class.new
       @option.value = value
       assert_same value, @option.value
     end
   end
-  
+
   class WithAValueKindOfTest < BaseTest
     desc "with a value is a kind of the class"
     setup do
@@ -209,7 +225,7 @@ class NsOptions::Option
       @child_class = Class.new(@class)
       @option = NsOptions::Option.new(:something, @class)
     end
-    
+
     should "use the object passed to it instead of creating a new one" do
       value = @child_class.new
       @option.value = value


### PR DESCRIPTION
- when an option's type class comes in as NilClass, an option will convert it to Object
- added a test to confirm when any option's value is set to nil, will use nil instead of
  trying to coerce it to it's type class

@kelredd - Apparently I had already put in if you set an option to nil it will use nil and not try to coerce it, so we were good to go there. I added, if a type class ever gets set to `NilClass` an option will use `Object` instead. This was achievable with a dynamic option:

``` ruby
# settings is a namespace
settings.something_not_defined = nil
settings.options[:something_not_defined].type_class # => NilClass, not good
```
