### PR TITLE
Mass assign options with namespace#apply

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -154,13 +154,14 @@ project.settings.movie_resolution.height  # => 800
 project.settings.movie_resolution.width   # => 600
 ```
 
-As the example shows, if you have a namespace and have a matching hash, it will automatically apply those values to that namespace. Also, if you include keys that are not defined options for your class, new options will be created for the values:
+As the example shows, if you have a namespace and have a matching hash, it will automatically apply those values to that namespace. Also, if you include keys that are not defined options for your namespace, new options will be created for the values:
 
 ```ruby
 project = Project.new
-project.settings.apply({ :stereoscopic => true })
+project.settings.apply({ :stereoscopic => true, :not_a_namespace => { :yes => true } })
 
-project.settings.stereoscopic   # => true
+project.settings.stereoscopic     # => true
+project.settings.not_a_namespace  # => { :yes => true }
 ```
 
 ## License

--- a/README.markdown
+++ b/README.markdown
@@ -16,7 +16,7 @@ The basic usage of Namespace Options is to be able to define options for a modul
 
 ```ruby
 module App
-  include NsOptions::HasOptions
+  include NsOptions
   options(:settings) do
     option :root, Pathname
     option :stage
@@ -98,7 +98,7 @@ Namespaces and their ability to read their parent's options is internally used b
 
 ```ruby
 class User
-  include NsOptions::HasOptions
+  include NsOptions
   options(:preferences) do
     option :home_page
   end
@@ -124,6 +124,44 @@ App.settings.logger.info("Hello World")
 ```
 
 Writing to a namespace with a previously undefined option will create a new option. The type class will be pulled from whatever object you write with. In the above case, the option defined would have it's type class set to `Logger` and would try to convert any new values to an instance of `Logger`.
+
+### Mass Assigning Options
+
+Sometimes, it's convenient to be able to set many options at once. This can be done by calling the `apply` method and giving it a hash of option names with values:
+
+```ruby
+class Project
+  include NsOptions
+  options(:settings) do
+    option :file_path
+    option :home_page
+
+    namespace(:movie_resolution) do
+      option :height, Integer
+      option :width, Integer
+    end
+  end
+end
+
+project = Project.new
+project.settings.apply({
+  :file_path => "/path/to/project",
+  :movie_resolution => { :height => 800, :width => 600 }
+})
+
+project.settings.file_path                # => "/path/to/project"
+project.settings.movie_resolution.height  # => 800
+project.settings.movie_resolution.width   # => 600
+```
+
+As the example shows, if you have a namespace and have a matching hash, it will automatically apply those values to that namespace. Also, if you include keys that are not defined options for your class, new options will be created for the values:
+
+```ruby
+project = Project.new
+project.settings.apply({ :stereoscopic => true })
+
+project.settings.stereoscopic   # => true
+```
 
 ## License
 

--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -79,6 +79,17 @@ module NsOptions
       namespace
     end
 
+    def apply(option_values = {})
+      option_values.each do |name, value|
+        is_namespace = (namespace = self.options.namespaces[name]) && value.kind_of?(Hash)
+        if self.options[name] || !is_namespace
+          self.send("#{name}=", value)
+        elsif is_namespace
+          namespace.apply(value)
+        end
+      end
+    end
+
     # The define method is provided for convenience and commonization. The internal system
     # uses it to commonly use a block with a namespace. The method can be used externally when
     # a namespace is created separately from where options are added/set on it. For example:

--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -81,10 +81,10 @@ module NsOptions
 
     def apply(option_values = {})
       option_values.each do |name, value|
-        is_namespace = (namespace = self.options.namespaces[name]) && value.kind_of?(Hash)
-        if self.options[name] || !is_namespace
+        namespace = self.options.namespaces[name]
+        if self.options[name] || !namespace
           self.send("#{name}=", value)
-        elsif is_namespace
+        elsif namespace && value.kind_of?(Hash)
           namespace.apply(value)
         end
       end


### PR DESCRIPTION
You can now use the `apply` method on a namespace to mass set options with a hash. This is recursive in that if you have a key matching a namespace name with a value that is a hash, it will apply that hash to the matching namespace. If you have extra keys that are not defined they will be added as dynamic options.

@kelredd - take a look, let me know if anything looks stupid
