### PR TITLE
Add an :args rule to options

### DIFF
--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -11,6 +11,7 @@ module NsOptions
     def required_set?
       self.options.required_set?
     end
+    alias :valid? :required_set?
 
     # Define an option for this namespace. Add the option to the namespace's options collection
     # and then define accessors for the option. With the following:

--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -9,6 +9,7 @@ module NsOptions
       self.name = name.to_s
       self.type_class = self.usable_type_class(type_class)
       self.rules = rules
+      self.rules[:args] = (self.rules[:args] ? [*self.rules[:args]] : [])
       self.value = rules[:default]
     end
 
@@ -51,7 +52,7 @@ module NsOptions
       elsif self.type_class == Hash
         {}.merge(new_value)
       else
-        self.type_class.new(new_value)
+        self.type_class.new(new_value, *self.rules[:args])
       end
     end
 

--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -49,6 +49,8 @@ module NsOptions
       if [ Integer, Float, String ].include?(self.type_class)
         # ruby type conversion, i.e. String(1)
         Object.send(self.type_class.to_s.to_sym, new_value)
+      elsif self.type_class == Symbol
+        new_value.to_sym
       elsif self.type_class == Hash
         {}.merge(new_value)
       else

--- a/test/unit/ns-options/namespace_test.rb
+++ b/test/unit/ns-options/namespace_test.rb
@@ -11,7 +11,7 @@ class NsOptions::Namespace
     subject{ @namespace }
 
     should have_accessors :metaclass, :options
-    should have_instance_methods :option, :namespace, :required_set?, :define, :apply
+    should have_instance_methods :option, :namespace, :required_set?, :define, :apply, :valid?
 
     should "have set it's metaclass accessor" do
       assert subject.metaclass

--- a/test/unit/ns-options/option_test.rb
+++ b/test/unit/ns-options/option_test.rb
@@ -132,6 +132,33 @@ class NsOptions::Option
     end
   end
 
+  class WithSymbolTypeClasstest < BaseTest
+    desc "with a Symbol as a type class"
+    setup do
+      @option = NsOptions::Option.new(:something, Symbol)
+    end
+
+    should "allow setting it with any object that responds to #to_sym" do
+      value = "amazing"
+      subject.value = value
+      assert_equal value.to_sym, subject.value
+      value = :another
+      subject.value = value
+      assert_equal value, subject.value
+      object_class = Class.new do
+        def to_sym; :object_sym; end
+      end
+      value = object_class.new
+      subject.value = value
+      assert_equal object_class.new.to_sym, subject.value
+    end
+    should "error on anything that doesn't define #to_sym" do
+      assert_raises(NoMethodError) do
+        subject.value = true
+      end
+    end
+  end
+
   class WithHashTypeClassTest < BaseTest
     desc "with a Hash as a type class"
     setup do
@@ -265,7 +292,7 @@ class NsOptions::Option
         @option = NsOptions::Option.new(:something, @class, { :args => @args })
         @option.value = @value
       end
-      
+
       should "pass the single value to the type class with the value" do
         expected = [*@args].insert(0, @value)
         assert_equal expected, subject.value.args
@@ -278,7 +305,7 @@ class NsOptions::Option
         @option = NsOptions::Option.new(:something, @class, { :args => @args })
         @option.value = @value
       end
-      
+
       should "just pass the value to the type class" do
         expected = [@value]
         assert_equal expected, subject.value.args

--- a/test/unit/ns-options/option_test.rb
+++ b/test/unit/ns-options/option_test.rb
@@ -233,4 +233,57 @@ class NsOptions::Option
     end
   end
 
+  class WithArgsTest < BaseTest
+    desc "with args rule"
+    setup do
+      @class = Class.new do
+        attr_accessor :args
+        def initialize(*args)
+          self.args = args
+        end
+      end
+      @value = "amazing"
+    end
+
+    class AsArrayTest < WithArgsTest
+      desc "as an array"
+      setup do
+        @args = [ true, false, { :hash => "yes" } ]
+        @option = NsOptions::Option.new(:something, @class, { :args => @args })
+        @option.value = @value
+      end
+
+      should "pass the args to the type class with the value" do
+        expected = @args.dup.insert(0, @value)
+        assert_equal expected, subject.value.args
+      end
+    end
+    class AsSingleValueTest < WithArgsTest
+      desc "as a single value"
+      setup do
+        @args = lambda{ "something" }
+        @option = NsOptions::Option.new(:something, @class, { :args => @args })
+        @option.value = @value
+      end
+      
+      should "pass the single value to the type class with the value" do
+        expected = [*@args].insert(0, @value)
+        assert_equal expected, subject.value.args
+      end
+    end
+    class AsNilValueTest < WithArgsTest
+      desc "as a nil value"
+      setup do
+        @args = nil
+        @option = NsOptions::Option.new(:something, @class, { :args => @args })
+        @option.value = @value
+      end
+      
+      should "just pass the value to the type class" do
+        expected = [@value]
+        assert_equal expected, subject.value.args
+      end
+    end
+  end
+
 end

--- a/test/unit/ns-options/options_test.rb
+++ b/test/unit/ns-options/options_test.rb
@@ -47,17 +47,17 @@ class NsOptions::Options
     should "have added a object option on itself when adding :my_string" do
       assert(option = subject[:my_string])
       assert_equal Object, option.type_class
-      assert_equal({}, option.rules)
+      assert_equal({ :args => [] }, option.rules)
     end
     should "have added an integer option on itself when adding :my_integer" do
       assert(option = subject[:my_integer])
       assert_equal Integer, option.type_class
-      assert_equal({}, option.rules)
+      assert_equal({ :args => [] }, option.rules)
     end
     should "have added a float option on itself when adding :my_float" do
       assert(option = subject[:my_float])
       assert_equal Float, option.type_class
-      assert_equal({ :default => 1.0 }, option.rules)
+      assert_equal(1.0, option.rules[:default])
     end
   end
 


### PR DESCRIPTION
Setting the :args rule will pass the value of the rule along with the new value for the option to your custom type class. This can be used to support having an initialize method that requires multiple parameters.

``` ruby
class MyTypeClass

  def initialize(first, second, third)
    # ... do something
  end

end

module App
  include NsOptions
  options(:settings) do
    option :special, MyTypeClass, :args => [ true, false ]
  end
end

App.settings.special = "yes" # => does MyTypeClass.new("yes", true, false)
```

This should not be combined with built-in ruby types (`String`, `Integer`, etc...) as it will be ignored and not passed to them.

I also included proper handling for ruby's symbols. There is no clear way to type-cast objects to symbols, so if you specify symbol as your type class, then it will try to call `to_sym` on your object. This will cover the common case of string to symbol, but can error with certain values.

@kelredd - take a look, let me know what you think
