### PR TITLE
Remove hierarchy of namespaces

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -282,7 +282,7 @@ Example.stuff.symbol # => :awesome, watch out, this will try calling to_sym on t
 Example.stuff.hash = { :a => 'b' }
 Example.stuff.hash # => returns the same hash, does Hash.new.merge(value)
 Example.stuff.array = [ 1, 2, 3 ]
-Example.stuff.array # => returns the same array, Array is the only one that works without anything special, Array.new(value) is done
+Example.stuff.array # => returns the same array, Array is the only one that works without anything special, Array.new(value)
 ```
 
 ### Option Rules

--- a/lib/ns-options/has_options.rb
+++ b/lib/ns-options/has_options.rb
@@ -13,19 +13,45 @@ module NsOptions
 
     module DSL
 
+      # This is the main DSL method for creating a namespace of options for your class/module. This
+      # will define a class method for both classes and modules and an additional instance method
+      # for classes. The namespace is then created and returned by calling the class method version.
+      # For classes, the instance method will build an entirely new namespace from the class level
+      # namespace. This is so when you define options at the class level:
+      #
+      # class Something
+      #   include NsOptions
+      #   options(:settings) do
+      #      option :root
+      #   end
+      # end
+      #
+      # the namespaces at the instance level still get all the defined options, but are completely
+      # separate objects from the class and other instances. Modules only deal with a single
+      # namespace at the module level.
       def options(name, key = nil, &block)
         key ||= name.to_s
-        self.class_eval <<-DEFINE_METHOD
-
-          def #{name}(&block)
-            @#{name} ||= NsOptions::Helper.new_child_namespace(self, '#{name}', &block)
-          end
+        method_definitions = <<-CLASS_METHOD
 
           def self.#{name}(&block)
-            @#{name} ||= NsOptions::Helper.new_namespace('#{key}', &block)
+            @#{name} ||= NsOptions::Namespace.new('#{key}', &block)
           end
 
-        DEFINE_METHOD
+        CLASS_METHOD
+        if self.kind_of?(Class)
+          method_definitions += <<-INSTANCE_METHOD
+
+            def #{name}(&block)
+              unless @#{name}
+                @#{name} = NsOptions::Namespace.new('#{key}', &block)
+                @#{name}.options.build_from(self.class.#{name}.options)
+              end
+              @#{name}
+            end
+
+          INSTANCE_METHOD
+        end
+        self.class_eval(method_definitions)
         self.send(name, &block)
       end
 

--- a/lib/ns-options/has_options.rb
+++ b/lib/ns-options/has_options.rb
@@ -44,7 +44,7 @@ module NsOptions
             def #{name}(&block)
               unless @#{name}
                 @#{name} = NsOptions::Namespace.new('#{key}', &block)
-                @#{name}.options.build_from(self.class.#{name}.options)
+                @#{name}.options.build_from(self.class.#{name}.options, @#{name})
               end
               @#{name}
             end

--- a/lib/ns-options/helper.rb
+++ b/lib/ns-options/helper.rb
@@ -3,30 +3,18 @@ module NsOptions
   module Helper
     module_function
 
-    # Common method for creating a new namespace
-    def new_namespace(key, parent = nil, &block)
-      namespace = NsOptions::Namespace.new(key, parent)
-      namespace.define(&block)
-    end
-
-    # Common method for creating a new child namespace, using the owner's class's options as the
-    # parent.
-    def new_child_namespace(owner, name, &block)
-      parent = owner.class.send(name)
-      method = "#{name}_key"
-      key = if owner.respond_to?(method)
-        owner.send(method)
-      else
-        "#{owner.class.to_s.split('::').last.downcase}_#{owner.object_id}"
-      end
-      namespace = parent.namespace(name, key)
-      namespace.define(&block)
-    end
-
+    # This method is a commonization of code used by a namespaces method_missing method. Essentially
+    # if the case arises that a namespace has an option defined (i.e. namespace.options[name] is
+    # not nil), then when you try to access it through a reader on the namespace, it will go to the
+    # method_missing for the namespace. This will see that there is an option and go ahead and
+    # define the reader/writer on the namespace. To do this, the option definition is found, and
+    # then duplicated with the namespace option method. The value that is currently set is also
+    # kept.
     def fetch_and_define_option(namespace, option_name)
-      option = namespace.options.fetch(option_name)
-      namespace.option(option.name, option.type_class, option.rules)
-      option
+      option = namespace.options[option_name]
+      new_option = namespace.option(option.name, option.type_class, option.rules)
+      new_option.value = option.value
+      new_option
     end
 
   end

--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -3,11 +3,17 @@ module NsOptions
   class Namespace
     attr_accessor :options, :metaclass
 
-    def initialize(key, parent = nil)
+    # Every namespace tracks a metaclass to allow for individual reader/writers for their options,
+    # without any collisions. Since every namespace is of the same class, defining option reader and
+    # writer methods directly on the class would make multiple namespaces with different options
+    # impossible.
+    def initialize(key, parent = nil, &block)
       self.metaclass = (class << self; self; end)
       self.options = NsOptions::Options.new(key, parent)
+      self.define(&block)
     end
 
+    # This is a helper to check if options that were defined as :required have been set.
     def required_set?
       self.options.required_set?
     end
@@ -65,7 +71,7 @@ module NsOptions
     # The defined namespaces is returned as well.
     def namespace(name, key = nil, &block)
       key = "#{self.options.key}:#{(key || name)}"
-      namespace = self.options.namespaces.add(name, key, self, &block)
+      namespace = self.options.add_namespace(name, key, self, &block)
 
       self.metaclass.class_eval <<-DEFINE_METHOD
 
@@ -80,6 +86,8 @@ module NsOptions
       namespace
     end
 
+    # The opposite of #to_hash. Takes a hash representation of options and namespaces and mass
+    # assigns option values.
     def apply(option_values = {})
       option_values.each do |name, value|
         namespace = self.options.namespaces[name]

--- a/lib/ns-options/namespaces.rb
+++ b/lib/ns-options/namespaces.rb
@@ -10,7 +10,7 @@ module NsOptions
     end
 
     def add(name, key, parent = nil, &block)
-      self[name] = NsOptions::Helper.new_namespace(key, parent, &block)
+      self[name] = NsOptions::Namespace.new(key, parent, &block)
     end
 
     def get(name)

--- a/lib/ns-options/options.rb
+++ b/lib/ns-options/options.rb
@@ -56,14 +56,15 @@ module NsOptions
       self.namespaces[name]
     end
 
-    def build_from(options)
+    def build_from(options, namespace)
       options.each do |key, option|
         self.add(option.name, option.type_class, option.rules)
+        NsOptions::Helper.find_and_define_option(namespace, option.name)
       end
-      options.namespaces.each do |name, namespace|
-        ns_options = namespace.options
-        new_namespace = self.add_namespace(name, ns_options.key, ns_options.parent)
-        new_namespace.options.build_from(ns_options)
+      options.namespaces.each do |name, ns|
+        new_namespace = self.add_namespace(name, ns.options.key, ns.options.parent)
+        NsOptions::Helper.find_and_define_namespace(namespace, name)
+        new_namespace.options.build_from(ns.options, new_namespace)
       end
     end
 

--- a/lib/ns-options/options.rb
+++ b/lib/ns-options/options.rb
@@ -46,14 +46,24 @@ module NsOptions
         bool && option.is_set?
       end
     end
-    
-    def add_namespace(name, key, parent = nil, &block)
+
+    def add_namespace(name, key = nil, parent = nil, &block)
+      key ||= name
       self.namespaces.add(name, key, parent, &block)
+    end
+
+    def get_namespace(name)
+      self.namespaces[name]
     end
 
     def build_from(options)
       options.each do |key, option|
         self.add(option.name, option.type_class, option.rules)
+      end
+      options.namespaces.each do |name, namespace|
+        ns_options = namespace.options
+        new_namespace = self.add_namespace(name, ns_options.key, ns_options.parent)
+        new_namespace.options.build_from(ns_options)
       end
     end
 

--- a/test/integration/app_test.rb
+++ b/test/integration/app_test.rb
@@ -55,9 +55,6 @@ module App
     should "have set the run_commands option" do
       assert_equal @run, subject.run_commands
     end
-    should "have access to it's parent's options" do
-      assert_equal @stage, subject.stage
-    end
   end
 
 end

--- a/test/integration/user_test.rb
+++ b/test/integration/user_test.rb
@@ -24,10 +24,37 @@ class User
     desc "instance"
     setup do
       @instance = @class.new
+      @class_preferences = @class.preferences
+      @class_preferences.home_url = "/something"
+      @preferences = @instance.preferences
     end
     subject{ @instance }
 
     should have_instance_methods :preferences
+
+    should "have a new namespace that is a different object than the class namespace" do
+      assert_equal @class_preferences.options.key, @preferences.options.key
+      assert_equal @class_preferences.options.parent, @preferences.options.parent
+      assert_not_same @class_preferences, @preferences
+    end
+    should "have the same options as the class namespace, but different objects" do
+      @class_preferences.options.each do |key, class_option|
+        option = @preferences.options[key]
+        assert_equal class_option.name, option.name
+        assert_equal class_option.type_class, option.type_class
+        assert_equal class_option.rules, option.rules
+        assert_not_same class_option, option
+      end
+      assert_not_equal @class_preferences.home_url, @preferences.home_url
+    end
+    should "have the same namespaces as the class namespace, but different objects" do
+      @class_preferences.options.namespaces.each do |name, class_namespace|
+        namespace = @preferences.options.namespaces[name]
+        assert_equal class_namespace.options.key, namespace.options.key
+        assert_equal class_namespace.options.parent, namespace.options.parent
+        assert_not_same class_namespace, namespace
+      end
+    end
   end
 
   class PreferencesTest < InstanceTest
@@ -37,11 +64,13 @@ class User
       @preferences.home_url = "/home"
       @preferences.show_messages = false
       @preferences.font_size = 15
+      @preferences.view.color = "green"
     end
     subject{ @preferences }
 
-    should have_instance_methods :namespace, :option, :define, :options, :metaclass
     should have_accessors :home_url, :show_messages, :font_size
+    should have_instance_methods :namespace, :option, :define, :options, :metaclass
+    should have_instance_methods :view
 
     should "have set the home_url" do
       assert_equal "/home", subject.home_url
@@ -51,6 +80,9 @@ class User
     end
     should "have set the font_size" do
       assert_equal 15, subject.font_size
+    end
+    should "have set the color option on the view sub namespace" do
+      assert_equal "green", subject.view.color
     end
   end
 

--- a/test/support/user.rb
+++ b/test/support/user.rb
@@ -7,6 +7,10 @@ class User
     option :home_url
     option :show_messages,  NsOptions::Option::Boolean, :require => true
     option :font_size,      Integer,                    :default => 12
+    
+    namespace :view do
+      option :color
+    end
   end
 
   def preferences_key

--- a/test/unit/ns-options/helper_test.rb
+++ b/test/unit/ns-options/helper_test.rb
@@ -9,55 +9,8 @@ module NsOptions::Helper
     end
     subject{ @module }
 
-    should have_instance_methods :new_namespace, :new_child_namespace, :fetch_and_define_option
+    should have_instance_methods :fetch_and_define_option
 
-  end
-
-  class NewNamespaceTest < BaseTest
-    desc "new_namespace method"
-    setup do
-      @parent = @module.new_namespace("parent")
-      @child = @module.new_namespace("child", @parent) do
-        option :something
-      end
-    end
-
-    should "have created a parent namespace" do
-      assert_equal "parent", @parent.options.key
-    end
-    should "have created a child namespace" do
-      assert_equal "child", @child.options.key
-      assert_equal @parent, @child.options.parent
-      assert @child.options[:something]
-    end
-  end
-  
-  class NewChildNamespaceTest < BaseTest
-    desc "new_child_namespace method"
-    setup do
-      @parent = @module.new_namespace("parent")
-      @mock_class = mock()
-      @mock_class.stubs(:super_settings).returns(@parent)
-      @first_owner = mock()
-      @first_owner.stubs({ :class => @mock_class })
-      @first = @module.new_child_namespace(@first_owner, "super_settings") do
-        option :something
-      end
-      @second_owner = User.new
-      @second = @module.new_child_namespace(@second_owner, "preferences")
-    end
-    
-    should "have created a child namespace" do
-      class_name = @mock_class.to_s.split('::').last.downcase
-      key = "#{@parent.options.key}:#{class_name}_#{@first_owner.object_id}"
-      assert_equal key, @first.options.key
-      assert_equal @parent, @first.options.parent
-      assert @first.options[:something]
-    end    
-    should "have created a second child namespace" do
-      key = "#{@second.options.parent.options.key}:#{@second_owner.preferences_key}"
-      assert_equal key, @second.options.key
-    end
   end
 
 end

--- a/test/unit/ns-options/helper_test.rb
+++ b/test/unit/ns-options/helper_test.rb
@@ -9,8 +9,39 @@ module NsOptions::Helper
     end
     subject{ @module }
 
-    should have_instance_methods :fetch_and_define_option
-
+    should have_instance_methods :find_and_define_namespace, :find_and_define_option,
+      :define_namespace_methods, :define_option_methods
+  end
+  
+  class FindAndDefineOptionTest < BaseTest
+    desc "find_and_define_option method"
+    setup do
+      @namespace = NsOptions::Namespace.new("something")
+      @option = @namespace.options.add(:anything)
+      @result = @module.find_and_define_option(@namespace, @option.name)
+    end
+    subject{ @namespace }
+    
+    should "have defined reader/writer methods for the option and returned the option" do
+      assert_respond_to @option.name, subject
+      assert_respond_to "#{@option.name}=", subject
+      assert_equal @option, @result
+    end
+  end 
+  
+  class FindAndDefineNamespaceTest < BaseTest
+    desc "find_and_define_namespace method"
+    setup do
+      @namespace = NsOptions::Namespace.new("something")
+      @namespace.options.add_namespace(:else, "something:else")
+      @result = @module.find_and_define_namespace(@namespace, :else)
+    end
+    subject{ @namespace }
+    
+    should "have defined reader method for the namespace and returned the namespace" do
+      assert_respond_to :else, subject
+      assert_equal subject.options.get_namespace(:else), @result
+    end
   end
 
 end

--- a/test/unit/ns-options/namespace_test.rb
+++ b/test/unit/ns-options/namespace_test.rb
@@ -153,10 +153,9 @@ class NsOptions::Namespace
   class MethodMissingTest < BaseTest
     desc "method missing"
     setup do
-      @parent = @namespace
-      @parent.options.add(:something)
-      @parent.options.set(:something, "amazing")
-      @namespace = NsOptions::Namespace.new("child", @parent)
+      @namespace = NsOptions::Namespace.new("strange")
+      @namespace.options.add(:something)
+      @namespace.options.set(:something, "amazing")
     end
 
     class ReaderForAKnownOptionTest < MethodMissingTest

--- a/test/unit/ns-options/namespaces_test.rb
+++ b/test/unit/ns-options/namespaces_test.rb
@@ -45,7 +45,7 @@ class NsOptions::Namespaces
 
   class GetTest < AddTest
     desc "get method"
-    
+
     should "return the namespace matching the name" do
       assert(namespace = subject.get("a_name"))
       assert_equal subject[:a_name], namespace

--- a/test/unit/ns-options/options_test.rb
+++ b/test/unit/ns-options/options_test.rb
@@ -172,13 +172,14 @@ class NsOptions::Options
   class BuildFromTest < BaseTest
     desc "build_from method"
     setup do
+      @namespace = NsOptions::Namespace.new("something")
       @from = NsOptions::Options.new(:something)
       @from.add(:root)
       @from.add_namespace(:else) do
         option :stage
       end
-      @options = NsOptions::Options.new(:another)
-      @options.build_from(@from)
+      @options = @namespace.options
+      @options.build_from(@from, @namespace)
     end
     subject{ @options }
 

--- a/test/unit/ns-options/options_test.rb
+++ b/test/unit/ns-options/options_test.rb
@@ -9,9 +9,9 @@ class NsOptions::Options
     end
     subject{ @options }
 
-    should have_accessors :key, :parent, :children
-    should have_instance_method :namespaces, :add, :del, :remove, :get, :set, :fetch, :is_defined?,
-      :parent_options
+    should have_accessors :key, :parent, :namespaces
+    should have_instance_method :add, :del, :remove, :get, :set, :fetch, :is_defined?,
+      :add_namespace
 
     should "be a kind of Hash" do
       assert_kind_of Hash, subject
@@ -31,7 +31,7 @@ class NsOptions::Options
       assert_nil subject.parent
     end
     should "return a kind of NsOption::Namespaces with a call to #children" do
-      assert_kind_of NsOptions::Namespaces, subject.children
+      assert_kind_of NsOptions::Namespaces, subject.namespaces
     end
   end
 
@@ -86,21 +86,6 @@ class NsOptions::Options
     should "have returned the option's value" do
       assert_equal @value, subject
     end
-
-    class WithParentTest < GetTest
-      desc "with a parent"
-      setup do
-        @parent = NsOptions::Namespace.new(:child)
-        @parent.options = @options
-        @options = NsOptions::Options.new(:child, @parent)
-        @result = @options.get(:my_string)
-      end
-      subject{ @result }
-
-      should "have returned the parent's option's value" do
-        assert_equal @value, subject
-      end
-    end
   end
 
   class SetTest < BaseTest
@@ -116,36 +101,6 @@ class NsOptions::Options
     end
   end
 
-  class FetchTest < BaseTest
-    desc "fetch method"
-    setup do
-      option = @options.add(:my_string)
-      @result = @options.fetch(:my_string)
-    end
-    subject{ @result }
-
-    should "return the option definition for my_string" do
-      assert_kind_of NsOptions::Option, subject
-      assert_equal "my_string", subject.name
-    end
-
-    class WithAParentTest < FetchTest
-      desc "with a parent"
-      setup do
-        @parent = NsOptions::Namespace.new(:child)
-        @parent.options = @options
-        @options = NsOptions::Options.new(:child, @parent)
-        @result = @options.fetch(:my_string)
-      end
-      subject{ @result }
-
-      should "return the option definition for my_string from it's parent" do
-        assert_kind_of NsOptions::Option, subject
-        assert_equal "my_string", subject.name
-      end
-    end
-  end
-
   class IsDefinedTest < BaseTest
     desc "fetch method"
     setup do
@@ -158,41 +113,6 @@ class NsOptions::Options
     end
     should "return false for an undefined option" do
       assert_equal false, subject.is_defined?(:undefined)
-    end
-
-    class WithAParentTest < IsDefinedTest
-      desc "with a parent"
-      setup do
-        @parent = NsOptions::Namespace.new(:child)
-        @parent.options = @options
-        @options = NsOptions::Options.new(:child, @parent)
-      end
-
-      should "return true for an option defined on it's parent" do
-        assert_equal true, subject.is_defined?(:my_string)
-      end
-    end
-  end
-
-  class ParentOptionsTest < BaseTest
-    desc "parent_options method"
-    subject{ @options }
-
-    should "return nil" do
-      assert_nil subject.parent_options
-    end
-
-    class WithAParentTest < ParentOptionsTest
-      desc "with a parent"
-      setup do
-        @parent = NsOptions::Namespace.new(:child)
-        @parent.options = @options
-        @options = NsOptions::Options.new(:child, @parent)
-      end
-
-      should "return it's parent's options" do
-        assert_equal @parent.options, subject.parent_options
-      end
     end
   end
 


### PR DESCRIPTION
These changes remove the hierarchy of namespaces that would allow child namespaces to read their parent's values. This fixes the weirdness with #18 and the strange "lazy-loading" of options seen with `to_hash`.

I also went ahead and updated the readme with a lot of the changes we've made recently.

@kelredd - look over it and let me know if anything doesn't make sense
