### PR TITLE
NsOptions::Proxy

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -382,6 +382,55 @@ App.settings.root # => /path/to/example, uses the args rule to build the path
 
 With the args rule, you can have a type class accept more than one argument. The first argument will always be the value to coerce. Any more arguments will be appended on after the value.
 
+## NsOptions::Proxy
+Mix in NsOptions::Proxy to any module/class to make it proxy a namespace.  This essentially turns your class into a namespace itself.  You can interact with it just as if it were a namespace object.  For example:
+
+```ruby
+module Something
+  include NsOptions
+  include NsOptions::Proxy
+
+  # define options directly
+  option :foo
+  option :bar, :default => "Bar"
+
+  # define sub-namespaces
+  namespace :more do
+    option :another
+  end
+
+end
+
+# handle those options
+Something.bar #=> "Bar"
+Something.to_hash  #=> {:foo => nil, :bar => "Bar"}
+Something.each do |opt_name, opt_value|
+  ...
+end
+```
+
+What's great is that while your Something behaves like a namespace, you can still define methods and add to it just as you would normally in Ruby:
+
+```ruby
+module Something
+  def self.awesome_bar
+    "Awesome #{bar}"
+  end
+end
+
+Something.awesome_bar  # => "Awesome Bar"
+```
+
+And remember, NsOptions is mixed in, so you can go ahead and create a root namespace as you normally would:
+
+```ruby
+module Something
+  options(:else) do
+    option :baz
+  end
+end
+```
+
 ## License
 
 Copyright (c) 2011 Collin Redding and Team Insight

--- a/lib/ns-options.rb
+++ b/lib/ns-options.rb
@@ -1,12 +1,13 @@
 module NsOptions
   autoload :HasOptions,     'ns-options/has_options'
+  autoload :Proxy,          'ns-options/proxy'
   autoload :Helper,         'ns-options/helper'
   autoload :Namespace,      'ns-options/namespace'
   autoload :Namespaces,     'ns-options/namespaces'
   autoload :Option,         'ns-options/option'
   autoload :Options,        'ns-options/options'
   autoload :VERSION,        'ns-options/version'
-  
+
   module Errors
     autoload :InvalidName, 'ns-options/errors/invalid_name'
   end

--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -1,0 +1,45 @@
+module NsOptions::Proxy
+
+  # Mix this in to any module or class to make it proxy a namespace
+  # this means you can interact with the module/class/class-instance as
+  # if it were a namespace object itself.  For example:
+
+  NAMESPACE = "__proxy_options__"
+
+  class << self
+
+    def included(receiver)
+      receiver.class_eval do
+        include NsOptions
+        options(NAMESPACE)
+
+        extend ProxyMethods
+        include ProxyMethods
+      end
+    end
+
+  end
+
+  module ProxyMethods
+
+    # just proxy to the NAMESPACE created when Proxy was mixed in
+
+    def method_missing(meth, *args, &block)
+      if (po = self.__proxy_options__) && po.respond_to?(meth.to_s)
+        po.send(method, *args, &block)
+      else
+        super
+      end
+    end
+
+    def respond_to?(*args)
+      if (po = self.__proxy_options__) && po.respond_to?(args.first.to_s)
+        true
+      else
+        super
+      end
+    end
+
+  end
+
+end

--- a/test/unit/ns-options/proxy_test.rb
+++ b/test/unit/ns-options/proxy_test.rb
@@ -1,0 +1,64 @@
+require 'assert'
+
+module NsOptions::Proxy
+
+  class BaseTests < Assert::Context
+    desc "NsOptions::Proxy"
+
+    def self.proxy_a_namespace
+      Assert::Macro.new do
+        should "create a default namespace to proxy to" do
+          assert_respond_to NAMESPACE, subject
+          assert_kind_of NsOptions::Namespace, subject.send(NAMESPACE)
+        end
+
+        should "respond to namespace methods" do
+          assert_respond_to :option, subject
+          assert_respond_to :namespace, subject
+          assert_respond_to :to_hash, subject
+          assert_respond_to :each, subject
+        end
+
+      end
+    end
+
+  end
+
+  class ModuleTests < BaseTests
+    desc "when mixed in to a module"
+    setup do
+      @mod = Module.new do
+        include NsOptions
+        include NsOptions::Proxy
+      end
+    end
+    subject { @mod }
+
+    should proxy_a_namespace
+
+  end
+
+  class ClassTests < BaseTests
+    desc "when mixed into a class"
+    setup do
+      @cls = Class.new do
+        include NsOptions
+        include NsOptions::Proxy
+      end
+    end
+
+  end
+
+  class ClassLevelTests < ClassTests
+    subject { @cls }
+    should proxy_a_namespace
+
+  end
+
+  class InstanceLevelTests < ClassTests
+    subject { @cls.new }
+    should proxy_a_namespace
+
+  end
+
+end


### PR DESCRIPTION
- a module/class mixin to make the receiver proxy to a namespace
- makes your module class feel like a namespace, but still have all the awesome of a normal ruby module/class
