### PR TITLE
inject type class name into value coercing init ArgumentErrors

### DIFF
--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -71,7 +71,11 @@ module NsOptions
       elsif self.type_class == Hash
         {}.merge(value)
       else
-        self.type_class.new(value, *self.rules[:args])
+        begin
+          self.type_class.new(value, *self.rules[:args])
+        rescue ArgumentError => err
+          raise ArgumentError, "#{self.type_class} `initialize': #{err.message}"
+        end
       end
     end
 

--- a/test/unit/ns-options/option_test.rb
+++ b/test/unit/ns-options/option_test.rb
@@ -230,6 +230,33 @@ class NsOptions::Option
     end
   end
 
+  class WithTypeClassArgErrorTests < BaseTest
+    desc "setting a value with arg error"
+    setup do
+      @err = begin
+        raise ArgumentError, "some test error"
+      rescue ArgumentError => err
+        err
+      end
+      class SuperSuperTestTest
+        def initialize(*args)
+          raise ArgumentError, "some test error"
+        end
+      end
+      @option = NsOptions::Option.new(:something, SuperSuperTestTest)
+    end
+
+    should "reraise the arg error, including its type_class in the error message" do
+      err = begin
+        @option.value = "arg error should be raised"
+      rescue Exception => err
+        err
+      end
+      assert_equal ArgumentError, err.class
+      assert_included @option.type_class.to_s, err.message
+    end
+  end
+
   class WithAValueOfTheSameClassTest < BaseTest
     desc "with a value of the same class"
     setup do


### PR DESCRIPTION
- just a something to help out the developer
- especially when using custom type classes

i got an arg error using a custom type class and had trouble tracking it down b/c the backtrace is in ns-options.  just wanted to give myself a clue as to what thing was raising the arg error.

Is there a better way to accomplish this same effect?
