### PR TITLE
not safely defining the NsOptions::AssertMacros module

### DIFF
--- a/lib/ns-options/assert_macros.rb
+++ b/lib/ns-options/assert_macros.rb
@@ -1,3 +1,4 @@
+module NsOptions; end
 module NsOptions::AssertMacros
 
   # a set of Assert macros to help write namespace definition and


### PR DESCRIPTION
- breaking in v0.3.0 if you require 'ns-options/assert-macros' before you require 'ns-options'
