### PR TITLE
Proxy options

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -380,6 +380,8 @@ App.settings.required_set? # => true
 
 To check if an option is set it will simply check if the value is not `nil`. If you are using a custom type class though, you can define an `is_set?` method and this will be used to check if an option is set.
 
+The built in `required_set?` method checks to see if all the options for the namespace that have been marked `:required => true` are set.  It does not recursively check any child namespaces.
+
 #### Args
 
 Another rule that you can specify is args. This allows you to pass more arguments to a type class.

--- a/README.markdown
+++ b/README.markdown
@@ -387,7 +387,6 @@ Mix in NsOptions::Proxy to any module/class to make it proxy a namespace.  This 
 
 ```ruby
 module Something
-  include NsOptions
   include NsOptions::Proxy
 
   # define options directly

--- a/README.markdown
+++ b/README.markdown
@@ -89,6 +89,28 @@ App.settings.server # => NoMethodError
 App.settings.data.server # => 127.0.0.1:1234
 ```
 
+### Less Verbose Definitions
+
+As an alternative to the above definition syntax, you can use an alternate less-verbose syntax:
+* `opts` for `options`
+* `opt` for `option`
+* `ns`  for `namespace`
+
+```ruby
+module App
+  include NsOptions
+
+  opts :settings do
+    opt :root, Pathname
+    opt :stage
+
+    ns :other_stuff do
+      opt :something
+    end
+  end
+end
+```
+
 #### With Classes
 
 Using `NsOptions` on a `Class` uses namespaces to create separate sets of options for every instance of your class created. This allows every instance to have different values for the set of options and not interfere with each other. For example with the following:

--- a/lib/ns-options/has_options.rb
+++ b/lib/ns-options/has_options.rb
@@ -13,11 +13,13 @@ module NsOptions
 
     module DSL
 
-      # This is the main DSL method for creating a namespace of options for your class/module. This
-      # will define a class method for both classes and modules and an additional instance method
-      # for classes. The namespace is then created and returned by calling the class method version.
-      # For classes, the instance method will build an entirely new namespace from the class level
-      # namespace. This is so when you define options at the class level:
+      # This is the main DSL method for creating a namespace of options for your
+      # class/module. This will define a class method for both classes and
+      # modules and an additional instance method for classes. The namespace is
+      # then created and returned by calling the class method version.  For
+      # classes, the instance method will build an entirely new namespace from
+      # the class level namespace. This is so when you define options at the
+      # class level:
       #
       # class Something
       #   include NsOptions
@@ -26,16 +28,16 @@ module NsOptions
       #   end
       # end
       #
-      # the namespaces at the instance level still get all the defined options, but are completely
-      # separate objects from the class and other instances. Modules only deal with a single
-      # namespace at the module level.
+      # the namespaces at the instance level still get all the defined options,
+      # but are completely separate objects from the class and other instances.
+      # Modules only deal with a single namespace at the module level.
 
       # The options method takes three args:
       # * `name` : what to name the defined methods for accessing the namespace
       # * `key`  : (optional) what to key the created namespace objects with
       #            - defaults to `name`
       #            - useful if persisting namespaces into some key-value store
-      # * `block`: (optional) a predefined set up nested options and namespaces
+      # * `block`: (optional) a predefined set of nested options and namespaces
 
       def options(name, key = nil, &block)
         NsOptions::Helper.advisor.is_this_namespace_ok?(name, caller)

--- a/lib/ns-options/has_options.rb
+++ b/lib/ns-options/has_options.rb
@@ -55,6 +55,7 @@ module NsOptions
         self.class_eval(method_definitions)
         self.send(name, &block)
       end
+      alias_method :opts, :options
 
     end
 

--- a/lib/ns-options/has_options.rb
+++ b/lib/ns-options/has_options.rb
@@ -29,6 +29,14 @@ module NsOptions
       # the namespaces at the instance level still get all the defined options, but are completely
       # separate objects from the class and other instances. Modules only deal with a single
       # namespace at the module level.
+
+      # The options method takes three args:
+      # * `name` : what to name the defined methods for accessing the namespace
+      # * `key`  : (optional) what to key the created namespace objects with
+      #            - defaults to `name`
+      #            - useful if persisting namespaces into some key-value store
+      # * `block`: (optional) a predefined set up nested options and namespaces
+
       def options(name, key = nil, &block)
         NsOptions::Helper.advisor.is_this_namespace_ok?(name, caller)
         key ||= name.to_s

--- a/lib/ns-options/has_options.rb
+++ b/lib/ns-options/has_options.rb
@@ -39,28 +39,7 @@ module NsOptions
 
       def options(name, key = nil, &block)
         NsOptions::Helper.advisor.is_this_namespace_ok?(name, caller)
-        key ||= name.to_s
-        method_definitions = <<-CLASS_METHOD
-
-          def self.#{name}(&block)
-            @#{name} ||= NsOptions::Namespace.new('#{key}', &block)
-          end
-
-        CLASS_METHOD
-        if self.kind_of?(Class)
-          method_definitions += <<-INSTANCE_METHOD
-
-            def #{name}(&block)
-              unless @#{name}
-                @#{name} = NsOptions::Namespace.new('#{key}', &block)
-                @#{name}.options.build_from(self.class.#{name}.options, @#{name})
-              end
-              @#{name}
-            end
-
-          INSTANCE_METHOD
-        end
-        self.class_eval(method_definitions)
+        NsOptions::Helper.define_root_namespace_methods(self, name, key)
         self.send(name, &block)
       end
       alias_method :opts, :options

--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -37,6 +37,7 @@ module NsOptions
       NsOptions::Helper.define_option_methods(self, option)
       option
     end
+    alias_method :opt, :option
 
     # Define a namespace under this namespace. Firstly, a new key is constructured from this current
     # namespace's key and the name for the new namespace. The namespace is then added to the
@@ -60,6 +61,7 @@ module NsOptions
       NsOptions::Helper.define_namespace_methods(self, name)
       namespace
     end
+    alias_method :ns, :namespace
 
     # The opposite of #to_hash. Takes a hash representation of options and namespaces and mass
     # assigns option values.

--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -22,7 +22,45 @@ module NsOptions::Proxy
 
   module ProxyMethods
 
-    # just proxy to the NAMESPACE created when Proxy was mixed in
+    # pass thru namespace methods to the proxied NAMESPACE handler
+
+    def option(*args, &block)
+      self.__proxy_options__.option(*args, &block)
+    end
+
+    def namespace(*args, &block)
+      self.__proxy_options__.namespace(*args, &block)
+    end
+
+    def apply(*args, &block)
+      self.__proxy_options__.apply(*args, &block)
+    end
+
+    def to_hash(*args, &block)
+      self.__proxy_options__.to_hash(*args, &block)
+    end
+
+    def each(*args, &block)
+      self.__proxy_options__.each(*args, &block)
+    end
+
+    def define(*args, &block)
+      self.__proxy_options__.define(*args, &block)
+    end
+
+    def inspect(*args, &block)
+      self.__proxy_options__.inspect(*args, &block)
+    end
+
+    def required_set?(*args, &block)
+      self.__proxy_options__.required_set?(*args, &block)
+    end
+
+    def valid?(*args, &block)
+      self.__proxy_options__.valid?(*args, &block)
+    end
+
+    # for everything else, send to the proxied NAMESPACE handler
 
     def method_missing(meth, *args, &block)
       if (po = self.__proxy_options__) && po.respond_to?(meth.to_s)

--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -1,18 +1,15 @@
+require 'ns-options'
+
 module NsOptions::Proxy
 
   # Mix this in to any module or class to make it proxy a namespace
   # this means you can interact with the module/class/class-instance as
-  # if it were a namespace object itself.  For example:
-
-  NAMESPACE = "__proxy_options__"
+  # if it were a namespace object itself.
 
   class << self
 
     def included(receiver)
       receiver.class_eval do
-        include NsOptions
-        options(NAMESPACE)
-
         extend ProxyMethods
         include ProxyMethods
       end
@@ -21,6 +18,12 @@ module NsOptions::Proxy
   end
 
   module ProxyMethods
+
+    # define the proxied NAMESPACE handler
+
+    def __proxy_options__
+      @__proxy_options__ ||= NsOptions::Namespace.new('__proxy_options__')
+    end
 
     # pass thru namespace methods to the proxied NAMESPACE handler
 
@@ -61,6 +64,7 @@ module NsOptions::Proxy
     end
 
     # for everything else, send to the proxied NAMESPACE handler
+    # at this point it really just gets dynamic option setting ability
 
     def method_missing(meth, *args, &block)
       if (po = self.__proxy_options__) && po.respond_to?(meth.to_s)

--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -30,10 +30,12 @@ module NsOptions::Proxy
     def option(*args, &block)
       self.__proxy_options__.option(*args, &block)
     end
+    alias_method :opt, :option
 
     def namespace(*args, &block)
       self.__proxy_options__.namespace(*args, &block)
     end
+    alias_method :ns, :namespace
 
     def apply(*args, &block)
       self.__proxy_options__.apply(*args, &block)

--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -12,10 +12,8 @@ module NsOptions::Proxy
 
     def included(receiver)
       NsOptions::Helper.define_root_namespace_methods(receiver, NAMESPACE)
-      receiver.class_eval do
-        extend ProxyMethods
-        include ProxyMethods
-      end
+      receiver.class_eval { extend ProxyMethods }
+      receiver.class_eval { include ProxyMethods } if receiver.kind_of?(Class)
     end
 
   end

--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -50,10 +50,6 @@ module NsOptions::Proxy
       __proxy_options__.define(*args, &block)
     end
 
-    def inspect(*args, &block)
-      __proxy_options__.inspect(*args, &block)
-    end
-
     def required_set?(*args, &block)
       __proxy_options__.required_set?(*args, &block)
     end

--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -6,9 +6,12 @@ module NsOptions::Proxy
   # this means you can interact with the module/class/class-instance as
   # if it were a namespace object itself.
 
+  NAMESPACE = "__proxy_options__"
+
   class << self
 
     def included(receiver)
+      NsOptions::Helper.define_root_namespace_methods(receiver, NAMESPACE)
       receiver.class_eval do
         extend ProxyMethods
         include ProxyMethods
@@ -19,54 +22,48 @@ module NsOptions::Proxy
 
   module ProxyMethods
 
-    # define the proxied NAMESPACE handler
-
-    def __proxy_options__
-      @__proxy_options__ ||= NsOptions::Namespace.new('__proxy_options__')
-    end
-
     # pass thru namespace methods to the proxied NAMESPACE handler
 
     def option(*args, &block)
-      self.__proxy_options__.option(*args, &block)
+      __proxy_options__.option(*args, &block)
     end
     alias_method :opt, :option
 
     def namespace(*args, &block)
-      self.__proxy_options__.namespace(*args, &block)
+      __proxy_options__.namespace(*args, &block)
     end
     alias_method :ns, :namespace
 
     def apply(*args, &block)
-      self.__proxy_options__.apply(*args, &block)
+      __proxy_options__.apply(*args, &block)
     end
 
     def to_hash(*args, &block)
-      self.__proxy_options__.to_hash(*args, &block)
+      __proxy_options__.to_hash(*args, &block)
     end
 
     def each(*args, &block)
-      self.__proxy_options__.each(*args, &block)
+      __proxy_options__.each(*args, &block)
     end
 
     def define(*args, &block)
-      self.__proxy_options__.define(*args, &block)
+      __proxy_options__.define(*args, &block)
     end
 
     def inspect(*args, &block)
-      self.__proxy_options__.inspect(*args, &block)
+      __proxy_options__.inspect(*args, &block)
     end
 
     def required_set?(*args, &block)
-      self.__proxy_options__.required_set?(*args, &block)
+      __proxy_options__.required_set?(*args, &block)
     end
 
     def valid?(*args, &block)
-      self.__proxy_options__.valid?(*args, &block)
+      __proxy_options__.valid?(*args, &block)
     end
 
     # for everything else, send to the proxied NAMESPACE handler
-    # at this point it really just gets dynamic option setting ability
+    # at this point it really just enables setting dynamic options
 
     def method_missing(meth, *args, &block)
       if (po = self.__proxy_options__) && po.respond_to?(meth.to_s)

--- a/test/unit/ns-options/has_options_test.rb
+++ b/test/unit/ns-options/has_options_test.rb
@@ -16,7 +16,7 @@ module NsOptions::HasOptions
     end
     subject{ @instance }
 
-    should have_class_methods :options
+    should have_class_methods :options, :opts
 
   end
 

--- a/test/unit/ns-options/helper_test.rb
+++ b/test/unit/ns-options/helper_test.rb
@@ -9,15 +9,19 @@ module NsOptions::Helper
     end
     subject{ @module }
 
-    should have_instance_methods :find_and_define_namespace, :find_and_define_option,
-      :define_namespace_methods, :define_option_methods, :advisor
-      
+    should have_instance_method :find_and_define_namespace
+    should have_instance_method :find_and_define_option
+    should have_instance_method :define_namespace_methods
+    should have_instance_method :define_option_methods
+    should have_instance_method :advisor
+    should have_instance_method :define_root_namespace_methods
+
     should "return an instance of NsOptions::Helper::Advisor with a call to #advisor" do
       advisor = subject.advisor(NsOptions::Namespace.new("something"))
       assert_instance_of NsOptions::Helper::Advisor, advisor
     end
   end
-  
+
   class FindAndDefineOptionTest < BaseTest
     desc "find_and_define_option method"
     setup do
@@ -26,14 +30,14 @@ module NsOptions::Helper
       @result = @module.find_and_define_option(@namespace, @option.name)
     end
     subject{ @namespace }
-    
+
     should "have defined reader/writer methods for the option and returned the option" do
       assert_respond_to @option.name, subject
       assert_respond_to "#{@option.name}=", subject
       assert_equal @option, @result
     end
-  end 
-  
+  end
+
   class FindAndDefineNamespaceTest < BaseTest
     desc "find_and_define_namespace method"
     setup do
@@ -42,7 +46,7 @@ module NsOptions::Helper
       @result = @module.find_and_define_namespace(@namespace, :else)
     end
     subject{ @namespace }
-    
+
     should "have defined reader method for the namespace and returned the namespace" do
       assert_respond_to :else, subject
       assert_equal subject.options.get_namespace(:else), @result

--- a/test/unit/ns-options/namespace_test.rb
+++ b/test/unit/ns-options/namespace_test.rb
@@ -11,7 +11,10 @@ class NsOptions::Namespace
     subject{ @namespace }
 
     should have_accessors :metaclass, :options
-    should have_instance_methods :option, :namespace, :required_set?, :define, :apply, :valid?
+    should have_instance_methods :option, :opt
+    should have_instance_methods :namespace, :ns
+    should have_instance_methods :required_set?, :valid?
+    should have_instance_methods :define, :apply
     should have_instance_methods :to_hash, :each
 
     should "have set it's metaclass accessor" do

--- a/test/unit/ns-options/proxy_test.rb
+++ b/test/unit/ns-options/proxy_test.rb
@@ -12,11 +12,16 @@ module NsOptions::Proxy
           assert_kind_of NsOptions::Namespace, subject.send(NAMESPACE)
         end
 
-        should "respond to namespace methods" do
-          assert_respond_to :option, subject
-          assert_respond_to :namespace, subject
-          assert_respond_to :to_hash, subject
-          assert_respond_to :each, subject
+        should "respond to proxied namespace methods" do
+          assert_respond_to :option,        subject
+          assert_respond_to :namespace,     subject
+          assert_respond_to :apply,         subject
+          assert_respond_to :to_hash,       subject
+          assert_respond_to :each,          subject
+          assert_respond_to :define,        subject
+          assert_respond_to :inspect,       subject
+          assert_respond_to :required_set?, subject
+          assert_respond_to :valid?,        subject
         end
 
         should "create options directly" do

--- a/test/unit/ns-options/proxy_test.rb
+++ b/test/unit/ns-options/proxy_test.rb
@@ -8,8 +8,8 @@ module NsOptions::Proxy
     def self.proxy_a_namespace
       Assert::Macro.new do
         should "create a default namespace to proxy to" do
-          assert_respond_to NAMESPACE, subject
-          assert_kind_of NsOptions::Namespace, subject.send(NAMESPACE)
+          assert_respond_to '__proxy_options__', subject
+          assert_kind_of NsOptions::Namespace, subject.send('__proxy_options__')
         end
 
         should "respond to proxied namespace methods" do
@@ -46,7 +46,6 @@ module NsOptions::Proxy
     desc "when mixed in to a module"
     setup do
       @mod = Module.new do
-        include NsOptions
         include NsOptions::Proxy
       end
     end
@@ -60,7 +59,6 @@ module NsOptions::Proxy
     desc "when mixed into a class"
     setup do
       @cls = Class.new do
-        include NsOptions
         include NsOptions::Proxy
       end
     end

--- a/test/unit/ns-options/proxy_test.rb
+++ b/test/unit/ns-options/proxy_test.rb
@@ -14,7 +14,9 @@ module NsOptions::Proxy
 
         should "respond to proxied namespace methods" do
           assert_respond_to :option,        subject
+          assert_respond_to :opt,           subject
           assert_respond_to :namespace,     subject
+          assert_respond_to :ns,            subject
           assert_respond_to :apply,         subject
           assert_respond_to :to_hash,       subject
           assert_respond_to :each,          subject


### PR DESCRIPTION
This is a set of updates related to the Proxy behavior and handling
### Declarative Proxying

Before, ns-options would proxy using only a `method_missing` approach.  This causes problems when classes have methods injected on them that nullify the `method_missing`.  For example when Rake injects a `namespace` method.  This change models the proxy more closely with the `Namespace` class.  Known methods a declaratively proxied and `method_missing` is only used when it would be used for the namespace itself (dynamic defining of options).
### Less Verbose definition syntax

Changed to make option definition more succinct:
- `opts` for `options`
- `opt` for `option`
- `ns` for `namespace`

Applied to the main `Options` and `Namespace` classes as well as the `Proxy` mixin
### Cleaned Up how Proxy is mixed in

Before, when mixing in the Proxy, it would mixin the main NsOptions module for you.  This had some unintended side-effects (such as mixing in an `options` method to the proxy).  I changed it so that mixing in the Proxy only adds in the proxied methods but defines the proxied `NAMESPACE` in the same way normal root level options are defined.  This involved commonizing that logic in a helper.

Also, before the Proxy would mixin proxy instance methods when included on a Module.  This is unnecessary so I change it to only mixin instance methods when included on Classes.
### README and Comment additions and cleanups

I added README docs for the less verbose syntax and embellished on some comments some
