### PR TITLE
Custom type class returned value handling

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -287,7 +287,45 @@ class Root < Pathname
 end
 ```
 
-With the revised `initialize` method, `NsOptions` will have no problems coercing values for your the type class. In some cases the above solution may not work for you, but don't worry. See the _Option Rules_ section for another way to solve this, specifically about the args rule. For an example of a custom type class, the included `NsOptions::Boolean` can be looked at. This is a special case, but it works as a type class with `NsOptions`.
+With the revised `initialize` method, `NsOptions` will have no problems coercing values for the type class. In some cases the above solution may not work for you, but don't worry. See the _Option Rules_ section for another way to solve this, specifically about the args rule. For an example of a custom type class, the included `NsOptions::Boolean` can be looked at. This is a special case, but it works as a type class with `NsOptions`.
+
+### Custom type class return values
+
+It may be useful to use a custom type class as a silent value handler.  You don't necessarily care that this option is some handler class - you just want flexible ways to set its value and get a meaningful return value when you read it.
+
+When reading option values, NsOptions will first check and see if the option value responds to the `returned_value` method.  If it does, NsOptions will return that value instead of the instance of the type class.  If not it will return the type class instance as normal.
+
+The included `NsOptions::Boolean` handler class does just this to ensure it always returns either `true` or `false`.  Here is another example:
+
+```ruby
+class HostedAt
+  # sanitized :hosted_at config
+  #  remove any trailing '/'
+  #  ensure single leading '/'
+
+  def initialize(value)
+    @hosted_at = value.sub(/\/+$/, '').sub(/^\/*/, '/')
+  end
+
+  def returned_value
+    @hosted_at
+  end
+end
+
+class Thing
+  include NsOptions
+
+  options :is do
+    option :hosted_at, HostedAt
+    option
+  end
+end
+
+thing = Thing.new
+thing.is.hosted_at  # => nil
+thing.is.hosted_at = "path/to/resource/"
+thing.is.hosted_at  # => "/path/to/resource"
+```
 
 ### Ruby Classes As A Type Class
 
@@ -314,7 +352,7 @@ Example.stuff.float = "5.0"
 Example.stuff.float # => 5.0, same as Float("5.0")
 ```
 
-`Symbol`, `Hash` and `Array` work, but ruby doesn't provide a built in type casting for these.
+`Symbol`, `Hash` and `Array` work, but ruby doesn't provide built in type casting for these.
 
 ```ruby
 Example.stuff.symbol = "awesome"
@@ -433,7 +471,7 @@ end
 
 ## License
 
-Copyright (c) 2011 Collin Redding and Team Insight
+Copyright (c) 2011-Present Collin Redding and Team Insight
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.markdown
+++ b/README.markdown
@@ -317,7 +317,6 @@ class Thing
 
   options :is do
     option :hosted_at, HostedAt
-    option
   end
 end
 

--- a/lib/ns-options/boolean.rb
+++ b/lib/ns-options/boolean.rb
@@ -11,6 +11,10 @@ module NsOptions
       @actual = self.convert(new_value)
     end
 
+    def returned_value
+      self.actual
+    end
+
     protected
 
     def convert(value)

--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -26,7 +26,13 @@ module NsOptions
     # if reading a lazy_proc, call the proc and return its coerced return val
     # otherwise, just return the stored value
     def value
-      self.lazy_proc?(@value) ? self.coerce(@value.call) : @value
+      if self.lazy_proc?(@value)
+        self.coerce(@value.call)
+      elsif @value.respond_to?(:returned_value)
+        @value.returned_value
+      else
+        @value
+      end
     end
 
     # if setting a lazy_proc, just store the proc off to be called when read

--- a/test/integration/app_test.rb
+++ b/test/integration/app_test.rb
@@ -61,8 +61,7 @@ module App
     subject{ @module.settings.sub }
 
     should "have set the run_commands option" do
-      assert_kind_of NsOptions::Boolean, subject.run_commands
-      assert_equal @run, subject.run_commands.actual
+      assert_equal @run, subject.run_commands
     end
   end
 

--- a/test/integration/user_test.rb
+++ b/test/integration/user_test.rb
@@ -79,8 +79,7 @@ class User
     end
 
     should "have set show_messages" do
-      assert_kind_of NsOptions::Boolean, subject.show_messages
-      assert_equal false, subject.show_messages.actual
+      assert_equal false, subject.show_messages
     end
 
     should "have set the font_size" do

--- a/test/unit/ns-options/boolean_test.rb
+++ b/test/unit/ns-options/boolean_test.rb
@@ -9,7 +9,17 @@ class NsOptions::Boolean
     end
     subject{ @boolean }
 
-    should have_accessors :actual
+    should have_accessor :actual
+    should have_reader   :returned_value
+
+    should "return its handled value with the `actual` method" do
+      assert_equal true, subject.actual
+    end
+
+    should "return its handled value with the `returned_value` method" do
+      assert_equal true, subject.returned_value
+    end
+
   end
 
   class WithTruthyValuesTest < BaseTest


### PR DESCRIPTION
### Honor option values responding to `returned_value`

There are times when it is nice to use a custom type class as a 'value handler'.  Typically this is to use a class to sanitize and validate incoming values.  You want to write a value and get the sanitized value of what is written back when reading that value.  You may not care that the value is a custom class - you just want the value of what the class processed.

This change will allow developers to define a `returned_value` method on the type classes.  If NsOptions sees that method it will call it and return its value when reading the option.  Otherwise it will behave as normal.
### Added to NsOptions::Boolean

I went ahead and added this to the Boolean handler class.  This is a great example of why you want something like this.  You shouldn't have to fuddle with all the actual junk when dealing with booleans.  I know I had previously committed changes that took out special boolean handling (f8f44ff0a7808544c4f40bf8c8400dfe0d9f7171) but I think this approach allows for a much more scalable way to support special return value handling.  It doesn't rely on the Option class doing kind_of? checks for example.
### Tests

I added tests for this.  I added a bunch of control tests when doing this.  I wanted to make sure I wasn't breaking the normal option value behavior if the `returned_value` method wasn't specified.  They may be too much - I'll let you decide and will modify if needed.
