### PR TITLE
Proxy default initialization behavior

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -454,6 +454,44 @@ module Something
 end
 ```
 
+### Proxy initialization
+
+Mixing in Proxy with mixin a default initializer for you as well.  This initializer allows you to call `new` on your proxy, passing it a hash of key-values.  These key values will be applied to the proxy using the `Namespace#apply` logic.  This allows you to use Proxy objects as option types and maintain the option type-casting and defaulting behavior.
+
+A Module example
+
+```ruby
+module Things
+  include NsOptions::Proxy
+
+  option :one
+  option :two
+end
+
+# proxy defines a `new` method that takes a hash arg and
+# applies it to the proxy
+t = Thing.new(:one => 1, :two => 2, :three => 3)
+
+# the values have been applied
+t.to_hash  # => {:one => 1, :two => 2, :three => 3}
+```
+
+# A Class example
+
+```
+class Thing
+  include NsOptions::Proxy
+
+  option :one
+  option :two
+end
+
+# proxy defines an `initialize` method that takes a hash arg and
+# applies it to the proxy
+t = Thing.new(:one => 1, :two => 2, :three => 3)
+t.to_hash  # => {:one => 1, :two => 2, :three => 3}
+```
+
 ## License
 
 Copyright (c) 2011 Collin Redding and Team Insight

--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -14,6 +14,26 @@ module NsOptions::Proxy
       NsOptions::Helper.define_root_namespace_methods(receiver, NAMESPACE)
       receiver.class_eval { extend ProxyMethods }
       receiver.class_eval { include ProxyMethods } if receiver.kind_of?(Class)
+
+      # default initializer method
+
+      if receiver.kind_of?(Class)
+        receiver.class_eval do
+
+          def initialize(configs={})
+            self.apply(configs || {})
+          end
+
+        end
+      else # Module
+        receiver.class_eval do
+
+          def self.new(configs={})
+            self.apply(configs || {})
+          end
+
+        end
+      end
     end
 
   end

--- a/test/unit/ns-options/proxy_test.rb
+++ b/test/unit/ns-options/proxy_test.rb
@@ -49,11 +49,34 @@ module NsOptions::Proxy
     setup do
       @mod = Module.new do
         include NsOptions::Proxy
+
+        option :test
       end
     end
     subject { @mod }
 
     should proxy_a_namespace
+
+    should "allow building from a hash of key-values" do
+      subject.new('test' => 1, 'more' => 2)
+
+      assert_equal 1, subject.test
+      assert_equal 2, subject.more
+    end
+
+    should "take `new` method overrides" do
+      @newmod = Module.new do
+        include NsOptions::Proxy
+
+        def self.new
+          # nothing
+        end
+      end
+
+      assert_raises ArgumentError do
+        @newmod.new('test' => 1, 'more' => 2)
+      end
+    end
 
   end
 
@@ -62,6 +85,8 @@ module NsOptions::Proxy
     setup do
       @cls = Class.new do
         include NsOptions::Proxy
+
+        option :test
       end
     end
 
@@ -76,6 +101,27 @@ module NsOptions::Proxy
   class InstanceLevelTests < ClassTests
     subject { @cls.new }
     should proxy_a_namespace
+
+    should "allow building from a hash of key-values" do
+      thing = @cls.new(:test => 1, :more => 2)
+
+      assert_equal 1, thing.test
+      assert_equal 2, thing.more
+    end
+
+    should "take init method overrides" do
+      @newcls = Class.new do
+        include NsOptions::Proxy
+
+        def initialize
+          # nothing
+        end
+      end
+
+      assert_raises ArgumentError do
+        @newcls.new('test' => 1, 'more' => 2)
+      end
+    end
 
   end
 


### PR DESCRIPTION
## Goal

Mixing in `Proxy` will add an "init style" method to the receiver with takes a single hash arg and applies it to the proxied namespace.
## Why

It would be nice to use Proxy classes as option types themselves.  Without some default initialization scheme, you can't do option defaulting or writing.  This provides a convention (that can be overridden) for initializing proxies.
