### PR TITLE
added an integration test to cover Proxy behavior

### DIFF
--- a/test/integration/proxy_test.rb
+++ b/test/integration/proxy_test.rb
@@ -1,0 +1,41 @@
+require 'assert'
+
+require 'ns-options/assert_macros'
+require 'test/support/proxy'
+
+class SomeProxyIntTests < Assert::Context
+  include NsOptions::AssertMacros
+
+  desc "the integration test proxy module"
+  setup do
+    @proxy = SomeProxy
+  end
+  subject { @proxy }
+
+  should have_option :some, SomeProxy::SomeThing, {
+    :default => {:value1 => 1}
+  }
+
+  should have_option :some_prime, SomeProxy::SomeThing, {
+    :default => {:value1 => 'one'}
+  }
+
+  should have_option :stuff, :default => []
+
+end
+
+class SomeProxySomeThingTests < SomeProxyIntTests
+  desc ":some option"
+  setup do
+    @proxy_some = @proxy.some
+  end
+  subject { @proxy_some }
+
+  should have_namespace :more
+  should have_options :value1, :value2
+
+  should "have its :value1 defaulted" do
+    assert_equal 1, subject.value1
+  end
+
+end

--- a/test/support/proxy.rb
+++ b/test/support/proxy.rb
@@ -1,0 +1,21 @@
+module SomeProxy
+  include NsOptions::Proxy
+
+  class SomeThing
+    include NsOptions::Proxy
+
+    opt :value1
+    opt :value2
+
+    ns :more do
+      opt :other1
+      opt :other2
+    end
+
+  end
+
+  opt :some, SomeThing, :default => { :value1 => 1 }
+  opt :some_prime, SomeThing, :default => { :value1 => 'one' }
+  opt :stuff, :default => []
+
+end


### PR DESCRIPTION
I wanted to add an integration test to cover (broadly) some relatively new logic that wasn't being tested at this level.  Specifically:
- mixing in NsOptions::Proxy
- using succinct definition syntax
- using a Proxy as an option type and defaulting
