### PR TITLE
Namespace Handling Enhancements

### DIFF
--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -116,6 +116,10 @@ module NsOptions
       self
     end
 
+    def ==(other_ns)
+      self.to_hash == other_ns.to_hash
+    end
+
     # There are a number of cases we want to watch for:
     # 1. A reader of a 'known' option. This case is for an option that's been defined for an
     #    ancestor of this namespace but not directly for this namespace. In this case we fetch

--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -117,7 +117,11 @@ module NsOptions
     end
 
     def ==(other_ns)
-      self.to_hash == other_ns.to_hash
+      if other_ns.kind_of? Namespace
+        self.to_hash == other_ns.to_hash
+      else
+        super
+      end
     end
 
     # There are a number of cases we want to watch for:

--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -15,19 +15,24 @@ module NsOptions::Proxy
       receiver.class_eval { extend ProxyMethods }
       receiver.class_eval { include ProxyMethods } if receiver.kind_of?(Class)
 
-      # default initializer method
-
       if receiver.kind_of?(Class)
         receiver.class_eval do
 
+          # default initializer method
           def initialize(configs={})
             self.apply(configs || {})
+          end
+
+          # equality method override for class-instance proxies
+          def ==(other_proxy_instance)
+            __proxy_options__ == other_proxy_instance.__proxy_options__
           end
 
         end
       else # Module
         receiver.class_eval do
 
+          # default initializer method
           def self.new(configs={})
             self.apply(configs || {})
           end

--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -81,6 +81,11 @@ module NsOptions::Proxy
       __proxy_options__.valid?(*args, &block)
     end
 
+    def inspect(*args, &block)
+      # __proxy_options__.inspect(*args, &block)
+      "#<#{self.class}:#{'0x%x' % (self.object_id << 1)}:#{__proxy_options__.options.key} #{__proxy_options__.to_hash.inspect}>"
+    end
+
     # for everything else, send to the proxied NAMESPACE handler
     # at this point it really just enables setting dynamic options
 

--- a/test/unit/ns-options/namespace_test.rb
+++ b/test/unit/ns-options/namespace_test.rb
@@ -401,17 +401,30 @@ class NsOptions::Namespace
 
 
   class EqualityTests < HandlingTests
-    desc "when compared to another namespace with the same named values"
+    desc "when compared for equality"
     setup do
       @namespace.apply(@named_values)
-
-      @other_ns = NsOptions::Namespace.new('other_something')
-      @other_ns.apply(@named_values)
     end
 
-    should "be equal to the other namespace" do
-      assert_equal @other_ns, @namespace
+    should "be equal to another namespace with the same named values" do
+      other_ns = NsOptions::Namespace.new('other_something')
+      other_ns.apply(@named_values)
+
+      assert_equal other_ns, @namespace
     end
+
+    should "not be equal to another namespace with different values" do
+      other_ns = NsOptions::Namespace.new('other_something')
+      other_ns.apply({:other => 'data'})
+
+      assert_not_equal other_ns, @namespace
+    end
+
+    should "not be equal to other things" do
+      assert_not_equal 1, @namespace
+      assert_not_equal @named_value, @namespace
+    end
+
   end
 
 

--- a/test/unit/ns-options/namespace_test.rb
+++ b/test/unit/ns-options/namespace_test.rb
@@ -400,5 +400,20 @@ class NsOptions::Namespace
   end
 
 
+  class EqualityTests < HandlingTests
+    desc "when compared to another namespace with the same named values"
+    setup do
+      @namespace.apply(@named_values)
+
+      @other_ns = NsOptions::Namespace.new('other_something')
+      @other_ns.apply(@named_values)
+    end
+
+    should "be equal to the other namespace" do
+      assert_equal @other_ns, @namespace
+    end
+  end
+
+
 
 end

--- a/test/unit/ns-options/proxy_test.rb
+++ b/test/unit/ns-options/proxy_test.rb
@@ -125,4 +125,23 @@ module NsOptions::Proxy
 
   end
 
+  class EqualityTests < InstanceLevelTests
+    desc "two class instance proxies with the same option values"
+    setup do
+      @proxy1 = @cls.new
+      @proxy2 = @cls.new
+
+      @option_values = {:test => 1, :more => 2}
+
+      @proxy1.apply(@option_values)
+      @proxy2.apply(@option_values)
+    end
+
+    should "be equal to the each other" do
+      assert_equal @proxy2, @proxy1
+    end
+
+
+  end
+
 end


### PR DESCRIPTION
## adding in namespace equality logic

Two namespaces with the same named values should be equal to each
other.  I chose to accomplish this by just comparing their hash
representations.
## equality testing for class instance proxies

Two class instance proxies should be equal if their proxied namespaces
are in turn equal.  Don't want to do this for the Module or Class level
proxying b/c that involve overriding the '==' method for `Class` and
`Module` - no good can come of that.
## better inspect method for proxies

This method essentially has the same logic as `Namespace#inspect`,
however it uses the proxy's class and object id info.
