### PR TITLE
namespace `reset` method

### DIFF
--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -58,6 +58,7 @@ module NsOptions
 
     def define(*args, &block);  @__data__.define(*args, &block);         end
     def build_from(other_ns);   @__data__.build_from(other_ns.__data__); end
+    def reset(*args, &block);   @__data__.reset(*args, &block);          end
     def apply(*args, &block);   @__data__.apply(*args, &block);          end
     def to_hash(*args, &block); @__data__.to_hash(*args, &block);        end
     def each(*args, &block);    @__data__.each(*args, &block);           end

--- a/lib/ns-options/namespace_data.rb
+++ b/lib/ns-options/namespace_data.rb
@@ -81,5 +81,10 @@ module NsOptions
       end
     end
 
+    def reset
+      child_options.each {|name, opt| opt.reset}
+      child_namespaces.each {|name, ns| ns.reset}
+    end
+
   end
 end

--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -21,7 +21,7 @@ module NsOptions
 
     def initialize(*args)
       self.rules, self.type_class, self.name = self.class.args(*args)
-      self.value = self.rules[:default]
+      self.reset
     end
 
     # if reading a lazy_proc, call the proc and return its coerced return val
@@ -40,6 +40,10 @@ module NsOptions
     # otherwise, coerce and store the value being set
     def value=(new_value)
       @value = self.lazy_proc?(new_value) ? new_value : self.coerce(new_value)
+    end
+
+    def reset
+      self.value = self.rules[:default]
     end
 
     def is_set?

--- a/test/unit/namespace_data_tests.rb
+++ b/test/unit/namespace_data_tests.rb
@@ -16,7 +16,7 @@ class NsOptions::NamespaceData
     should have_imeths :has_option?, :has_namespace?, :required_set?
     should have_imeths :add_option, :get_option, :set_option
     should have_imeths :add_namespace, :get_namespace
-    should have_imeths :to_hash, :apply, :each, :define, :build_from
+    should have_imeths :to_hash, :apply, :each, :define, :build_from, :reset
 
     should "know its namespace" do
       assert_equal @ns, subject.ns
@@ -180,6 +180,34 @@ class NsOptions::NamespaceData
       assert subject.has_namespace?(:ns1)
       assert subject.child_namespaces[:ns1].__data__.has_option? :sub_opt1
       assert_not_same @from_child_ns, subject.child_namespaces[:ns1]
+    end
+
+  end
+
+  class ResetTests < BaseTests
+    desc "reset method"
+    setup do
+      @data.add_option 'fixnum', Fixnum, :default => 10
+      @data.add_option 'something'
+      @data.add_namespace 'sub' do
+        option 'subopt'
+      end
+
+      @data.set_option 'fixnum', 9999
+      @data.set_option 'something', 'else'
+      @data.get_namespace('sub').subopt = "a subopt"
+    end
+
+    should "set the options back to their default values" do
+      assert_equal 9999, subject.get_option('fixnum')
+      assert_equal 'else', subject.get_option('something')
+      assert_equal 'a subopt', subject.get_namespace('sub').subopt
+
+      subject.reset
+
+      assert_equal 10, subject.get_option('fixnum')
+      assert_nil subject.get_option('something')
+      assert_nil subject.get_namespace('sub').subopt
     end
 
   end

--- a/test/unit/namespace_tests.rb
+++ b/test/unit/namespace_tests.rb
@@ -14,7 +14,7 @@ class NsOptions::Namespace
     should have_reader :__data__
     should have_imeths :option, :opt, :namespace, :ns
     should have_imeths :required_set?, :valid?, :has_option?, :has_namespace?
-    should have_imeths :define, :build_from, :apply, :to_hash, :each
+    should have_imeths :define, :build_from, :reset, :apply, :to_hash, :each
 
     should "contain its name key in its inspect output" do
       assert_included ":something", subject.inspect

--- a/test/unit/option_tests.rb
+++ b/test/unit/option_tests.rb
@@ -1,4 +1,6 @@
 require 'assert'
+require 'ns-options/option'
+require 'ns-options/boolean'
 
 class NsOptions::Option
 
@@ -11,8 +13,9 @@ class NsOptions::Option
     end
     subject{ @option }
 
-    should have_class_method :rules, :args
+    should have_class_methods :rules, :args
     should have_accessors :name, :value, :type_class, :rules
+    should have_imeths :is_set?, :required?, :reset
 
     should "have set the name" do
       assert_equal "stage", subject.name
@@ -37,6 +40,16 @@ class NsOptions::Option
     should "allow setting the value to nil" do
       subject.value = nil
       assert_nil subject.value
+    end
+
+    should "allow resetting the value to its default" do
+      assert_equal "development", subject.value
+      subject.value = "overwritten"
+      assert_equal "overwritten", subject.value
+
+      subject.reset
+
+      assert_equal "development", subject.value
     end
   end
 


### PR DESCRIPTION
This adds the ability to reset a namespace.  This means you recursively
set all options on the namespace back to their default values.
