### PR TITLE
custom exception handling when coercing

### DIFF
--- a/test/unit/option_tests.rb
+++ b/test/unit/option_tests.rb
@@ -207,7 +207,7 @@ class NsOptions::Option
     end
 
     should "error on anything that doesn't define #to_sym" do
-      assert_raises(NoMethodError) do
+      assert_raises(NsOptions::Option::CoerceError) do
         subject.value = true
       end
     end
@@ -279,7 +279,7 @@ class NsOptions::Option
       rescue Exception => err
         err
       end
-      assert_equal ArgumentError, err.class
+      assert_equal NsOptions::Option::CoerceError, err.class
       assert_included @option.type_class.to_s, err.message
     end
 


### PR DESCRIPTION
This captures any and all exceptions during option coercing and
raises the error as a custom `CoerceError` exception with a custom
message.  It preserves the backtrace of the original error.

Addresses #38.
