### PR TITLE
Immutable :value options

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,26 @@ A default runs through the same logic as if you set the value manually, so it wi
 ```ruby
 settings do
   option :opt1, :value => "development"
+
+  namespace 'immutable_things', :values do
+    option :val1, :default => 'something'
+    option :val2
+  end
 end
+
 settings.opt1                #=> 'development'
-settings.opt1 = 'production' #=> NoMethodError: undefined method opt1= ...
-settings.opt1 'production'   #=> ArgumentError: wrong number of arguments ...
+settings.opt1 = 'production' #=> NsOptions::OptionWriteError: can't write the :value ...
+settings.opt1 'production'   #=> NsOptions::OptionWriteError: can't write the :value ...
+
+settings.immutable_things.val1                #=> 'something'
+settings.immutable_things.val1 = 'another'    #=> NsOptions::OptionWriteError ...
+
+settings.immutable_things.val2                #=> nil
+settings.immutable_things.val2 = 'else'       #=> 'else'
+settings.immutable_things.val2 = 'different'  #=> NsOptions::OptionWriteError ...
 ```
 
-Specifying an option with a `:value` makes it immutable.
+Specifying an option with a `:value` rule makes it immutable.  Creating a namespace using the `:values` flag makes every option under it (recursively) immutable.
 
 #### Required
 

--- a/README.md
+++ b/README.md
@@ -200,16 +200,29 @@ Example.stuff.array  # => returns the same array
 
 An option can be defined with certain rules that extend the behavior of the option.
 
-#### Default Value
+#### Default
 
 ```ruby
 settings do
   option :opt1, :default => "development"
 end
-settings.opt1 #=> 'development'
+settings.opt1                #=> 'development'
+settings.opt1 = 'production' #=> 'production'
 ```
 
-A default value runs through the same logic as if you set the value manually, so it will be coerced if necessary.
+A default runs through the same logic as if you set the value manually, so it will be coerced if necessary.
+
+#### Value
+
+```ruby
+settings do
+  option :opt1, :value => "development"
+end
+settings.opt1                #=> 'development'
+settings.opt1 = 'production' #=> NoMethodError: undefined method opt1= ...
+```
+
+Specifying an option with a `:value` makes it immutable.
 
 #### Required
 
@@ -287,7 +300,7 @@ explicit.a_proc #=> <the proc obj>
 
 ## NsOptions::Proxy
 
-Mix in NsOptions::Proxy to any module/class to make it proxy a namespace.  This essentially turns your receiver into a namespace - you can interact with it just as if it were a namespace object.  For example:
+Mix in `NsOptions::Proxy` to any module/class to make it proxy a namespace.  This essentially turns your receiver into a namespace - you can interact with it just as if it were a namespace object.  For example:
 
 ```ruby
 module Something

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ settings do
 end
 settings.opt1                #=> 'development'
 settings.opt1 = 'production' #=> NoMethodError: undefined method opt1= ...
+settings.opt1 'production'   #=> ArgumentError: wrong number of arguments ...
 ```
 
 Specifying an option with a `:value` makes it immutable.

--- a/lib/ns-options.rb
+++ b/lib/ns-options.rb
@@ -13,9 +13,9 @@ module NsOptions
     # class/module. This will define a class method for classes/modules and
     # an additional instance method for classes.
 
-    def options(name, &block)
+    def options(name, *args, &block)
       NsOptions::RootMethods.new(self, name).define($stdout, caller)
-      self.send(name, &block)
+      self.send(name, *args, &block)
     end
     alias_method :opts,      :options
     alias_method :namespace, :options

--- a/lib/ns-options/assert_macros.rb
+++ b/lib/ns-options/assert_macros.rb
@@ -40,7 +40,7 @@ module NsOptions::AssertMacros
 
     def have_option(*args)
       called_from = caller.first
-      rules, type_class, opt_name = NsOptions::Option.args(*args)
+      opt_name, type_class, rules = NsOptions::Option.args(*args)
       test_name = [
         "have an option: '#{opt_name}'",
         "of type '#{type_class}'",

--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -59,9 +59,22 @@ module NsOptions
     def define(*args, &block);  @__data__.define(*args, &block);         end
     def build_from(other_ns);   @__data__.build_from(other_ns.__data__); end
     def reset(*args, &block);   @__data__.reset(*args, &block);          end
-    def apply(*args, &block);   @__data__.apply(*args, &block);          end
     def to_hash(*args, &block); @__data__.to_hash(*args, &block);        end
     def each(*args, &block);    @__data__.each(*args, &block);           end
+
+    # The opposite of #to_hash. Takes a hash representation of options and
+    # namespaces and mass assigns option values.
+    def apply(values=nil)
+      (values || {}).each do |name, value|
+        if has_namespace?(name) && value.kind_of?(Hash)
+          # recursively apply namespace values
+          @__data__.get_namespace(name).apply(value)
+        else
+          # write the option value
+          self.send("#{name}=", value)
+        end
+      end
+    end
 
     def ==(other_ns)
       if other_ns.kind_of? Namespace

--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -7,8 +7,8 @@ module NsOptions
 
     attr_reader :__data__
 
-    def initialize(name, &block)
-      @__data__ = NamespaceData.new(self, name)
+    def initialize(name, handling=nil, &block)
+      @__data__ = NamespaceData.new(self, name, handling)
       @__data__.define(&block)
     end
 
@@ -18,9 +18,9 @@ module NsOptions
     end
     alias_method :opt, :option
 
-    def namespace(name, &block)
+    def namespace(name, *args, &block)
       NamespaceAdvisor.new(@__data__, name, 'a namespace').run($stdout, caller)
-      @__data__.add_namespace(name, &block)
+      @__data__.add_namespace(name, *args, &block)
     end
     alias_method :ns, :namespace
 

--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -25,49 +25,14 @@ module NsOptions
     alias_method :ns, :namespace
 
     def respond_to?(meth)
-      name = meth.to_s.gsub("=", "")
-      writer = !!(meth.to_s =~ /=\Z/)
-
-      has_namespace?(name) ||              # namespace reader
-      (has_option?(name) && !writer) ||    # option reader
-      (writer && !value_option?(name)) ||  # option writer
-      super
+      @__data__.ns_respond_to?(meth) || super
     end
 
     def method_missing(meth, *args, &block)
-      data_name = meth.to_s.gsub("=", "")
-      writer_meth = !!(meth.to_s =~ /=\Z/)
-      data_to_write = !args.empty?
-      value = args.size == 1 ? args[0] : args
-
-      if has_namespace?(data_name)
-        # TODO: remove same named opt/ns when adding the other with same name
-        # read a known child namespace
-        @__data__.get_namespace(data_name).define(&block)
-      elsif has_option?(data_name) && !data_to_write
-        # read the defined option
-        @__data__.get_option(data_name)
-      elsif data_to_write && !value_option?(data_name)
-        # define the option if needed (dynamic writer)
-        @__data__.add_option(data_name) unless has_option?(data_name)
-        # write the defined option
-        @__data__.set_option(data_name, value)
-      elsif data_to_write && value_option?(data_name) && !writer_meth
-        # trying to write a :value option using the reader w/ args
-        err = ArgumentError.new("wrong number of arguments (#{args.size} for 0)")
-        err.set_backtrace(caller)
-        raise err
-      else
-        # trying to write a :value option using the writer
-        # or other unknown method
-        err = NoMethodError.new("undefined method `#{meth}' for #{self.inspect}")
-        err.set_backtrace(caller)
-        raise err
-      end
+      @__data__.ns_method_missing(caller, meth, *args, &block)
     end
 
     def has_option?(name);    @__data__.has_option?(name);    end
-    def value_option?(name);  @__data__.value_option?(name);  end
     def has_namespace?(name); @__data__.has_namespace?(name); end
     def required_set?;        @__data__.required_set?;        end
     alias_method :valid?, :required_set?
@@ -75,22 +40,9 @@ module NsOptions
     def define(*args, &block);  @__data__.define(*args, &block);         end
     def build_from(other_ns);   @__data__.build_from(other_ns.__data__); end
     def reset(*args, &block);   @__data__.reset(*args, &block);          end
+    def apply(*args, &block);   @__data__.apply(*args, &block);          end
     def to_hash(*args, &block); @__data__.to_hash(*args, &block);        end
     def each(*args, &block);    @__data__.each(*args, &block);           end
-
-    # The opposite of #to_hash. Takes a hash representation of options and
-    # namespaces and mass assigns option values.
-    def apply(values=nil)
-      (values || {}).each do |name, value|
-        if has_namespace?(name) && value.kind_of?(Hash)
-          # recursively apply namespace values
-          @__data__.get_namespace(name).apply(value)
-        else
-          # write the option value
-          self.send("#{name}=", value)
-        end
-      end
-    end
 
     def ==(other_ns)
       if other_ns.kind_of? Namespace

--- a/lib/ns-options/namespace_data.rb
+++ b/lib/ns-options/namespace_data.rb
@@ -37,24 +37,6 @@ module NsOptions
       end
     end
 
-    # The opposite of #to_hash. Takes a hash representation of options and namespaces and mass
-    # assigns option values.
-    def apply(values = {})
-      values.each do |name, value|
-        if has_option?(name)
-          # set a pre-defined option value
-          set_option(name, value)
-        elsif has_namespace?(name) && value.kind_of?(Hash)
-          # recursively set namespace values
-          get_namespace(name).apply(value)
-        elsif !has_option?(name)
-          # dynamically add a non-pre-defined option value
-          add_option(name)
-          set_option(name, value)
-        end
-      end
-    end
-
     # allow for iterating over the key/values of a namespace
     # this uses #to_hash so you won't get option/namespace objs for the values
     def each

--- a/lib/ns-options/namespace_data.rb
+++ b/lib/ns-options/namespace_data.rb
@@ -24,6 +24,10 @@ module NsOptions
     def set_option(name, val); @child_options.set(name, val);  end
     def add_option(*args);     @child_options.add(*args);      end
 
+    def value_option?(name)
+      (opt = @child_options[name]) && opt.rules.has_key?(:value)
+    end
+
     def has_namespace?(name);        !!@child_namespaces[name];           end
     def get_namespace(name);         @child_namespaces.get(name);         end
     def add_namespace(name, &block); @child_namespaces.add(name, &block); end

--- a/lib/ns-options/namespaces.rb
+++ b/lib/ns-options/namespaces.rb
@@ -3,7 +3,8 @@ require 'ns-options/namespace'
 module NsOptions
   class Namespaces
 
-    def initialize
+    def initialize(handling=nil)
+      @handling = handling || :default
       @hash = Hash.new
     end
 
@@ -15,8 +16,8 @@ module NsOptions
     def each(*args, &block);   @hash.each(*args, &block);   end
     def empty?(*args, &block); @hash.empty?(*args, &block); end
 
-    def add(name, &block)
-      self[name] = NsOptions::Namespace.new(name, &block)
+    def add(name, handling=nil, &block)
+      self[name] = NsOptions::Namespace.new(name, handling || @handling, &block)
     end
 
     def get(name); self[name]; end

--- a/lib/ns-options/namespaces.rb
+++ b/lib/ns-options/namespaces.rb
@@ -1,11 +1,19 @@
 require 'ns-options/namespace'
 
 module NsOptions
-  class Namespaces < Hash
+  class Namespaces
+
+    def initialize
+      @hash = Hash.new
+    end
 
     # for hash with indifferent access behavior
-    def [](name);         super(name.to_sym);        end
-    def []=(name, value); super(name.to_sym, value); end
+    def [](name);         @hash[name.to_s];         end
+    def []=(name, value); @hash[name.to_s] = value; end
+
+    def keys(*args, &block);   @hash.keys(*args, &block);   end
+    def each(*args, &block);   @hash.each(*args, &block);   end
+    def empty?(*args, &block); @hash.empty?(*args, &block); end
 
     def add(name, &block)
       self[name] = NsOptions::Namespace.new(name, &block)
@@ -14,9 +22,13 @@ module NsOptions
     def get(name); self[name]; end
 
     def required_set?
-      self.values.inject(true) do |bool, ns|
-        bool && ns.required_set?
-      end
+      are_all_these_namespaces_set? @hash.values
+    end
+
+    private
+
+    def are_all_these_namespaces_set?(namespaces)
+      namespaces.inject(true) {|bool, ns| bool && ns.is_set?}
     end
 
   end

--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -21,13 +21,17 @@ module NsOptions
         # this makes the option accept any value with no type coercion
         (args[1] || Object),
         args[0].to_s
-      ]
+      ].reverse
     end
 
     attr_accessor :name, :value, :type_class, :rules
 
-    def initialize(*args)
-      self.rules, self.type_class, self.name = self.class.args(*args)
+    def initialize(name, type_class=nil, rules=nil)
+      @name, @rules = name
+      @type_class = type_class || Object
+      @rules = rules || {}
+      @rules[:args] ||= []
+
       self.reset
     end
 

--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -2,12 +2,20 @@ module NsOptions
 
   class Option
 
+    class WriteError < RuntimeError
+      def initialize(name)
+        super("can't write the :value option `#{name}'.")
+      end
+    end
+
     class CoerceError < ::ArgumentError
       def initialize(type_class, value, err)
         super("can't coerce `#{value.inspect}' to `#{type_class}': #{err.message}")
         set_backtrace(err.backtrace)
       end
     end
+
+    class PendingValue; end
 
     def self.rules(rules)
       (rules || {}).tap do |r|
@@ -47,13 +55,16 @@ module NsOptions
       end
     end
 
-    # always save the rules' :value if there is one (makes option immutable)
     def value=(new_value)
-      save_value(self.rules.has_key?(:value) ? self.rules[:value] : new_value)
+      # can't write if a value rule has been set (makes opt immutable)
+      raise WriteError.new(@name) if value_rule_set?
+
+      # if a :value rule is pending, set it as well as the option value
+      save_value(value_rule_pending? ? self.rules[:value]=new_value : new_value)
     end
 
     def reset
-      self.value = self.rules[:default]
+      save_value(self.rules.has_key?(:value) ? self.rules[:value] : self.rules[:default])
     end
 
     def is_set?
@@ -88,7 +99,7 @@ module NsOptions
     end
 
     def coerce(value)
-      return value if (value.kind_of?(self.type_class)) || value.nil?
+      return value if no_coercing_needed?(value)
 
       begin
         if [ Integer, Float, String ].include?(self.type_class)
@@ -104,6 +115,20 @@ module NsOptions
       rescue Exception => err
         raise CoerceError.new(self.type_class, value, err)
       end
+    end
+
+    private
+
+    def value_rule_set?
+      self.rules.has_key?(:value) && self.rules[:value] != PendingValue
+    end
+
+    def value_rule_pending?
+      self.rules.has_key?(:value) && self.rules[:value] == PendingValue
+    end
+
+    def no_coercing_needed?(value)
+      value == PendingValue || value.kind_of?(self.type_class) || value.nil?
     end
 
   end

--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -43,10 +43,9 @@ module NsOptions
       end
     end
 
-    # if setting a lazy_proc, just store the proc off to be called when read
-    # otherwise, coerce and store the value being set
+    # always save the rules' :value if there is one (makes option immutable)
     def value=(new_value)
-      @value = self.lazy_proc?(new_value) ? new_value : self.coerce(new_value)
+      save_value(self.rules.has_key?(:value) ? self.rules[:value] : new_value)
     end
 
     def reset
@@ -68,6 +67,12 @@ module NsOptions
     end
 
     protected
+
+    # if setting a lazy_proc, just store the proc off to be called when read
+    # otherwise, coerce and store the value being set
+    def save_value(new_value)
+      @value = self.lazy_proc?(new_value) ? new_value : self.coerce(new_value)
+    end
 
     # a value is considered to by a lazy eval proc if it some kind of a of
     # Proc and the option it is being set on is not explicitly defined as some

--- a/lib/ns-options/options.rb
+++ b/lib/ns-options/options.rb
@@ -1,14 +1,25 @@
 require 'ns-options/option'
 
 module NsOptions
-  class Options < Hash
+  class Options
+
+    def initialize(option_type=nil)
+      @option_type = option_type || :default
+      @hash = Hash.new
+    end
 
     # for hash with indifferent access behavior
-    def [](name);         super(name.to_sym);        end
-    def []=(name, value); super(name.to_sym, value); end
+    def [](name);         @hash[name.to_s];         end
+    def []=(name, value); @hash[name.to_s] = value; end
+
+    def keys(*args, &block);   @hash.keys(*args, &block);   end
+    def each(*args, &block);   @hash.each(*args, &block);   end
+    def empty?(*args, &block); @hash.empty?(*args, &block); end
 
     def add(*args)
-      option = NsOptions::Option.new(*args)
+      name, type_class, rules = NsOptions::Option.args(*args)
+
+      option = NsOptions::Option.new(name, type_class, rules)
       self[option.name] = option
     end
 
@@ -25,9 +36,17 @@ module NsOptions
     end
 
     def required_set?
-      self.values.reject{|option| !option.required? }.inject(true) do |bool, option|
-        bool && option.is_set?
-      end
+      are_all_these_options_set? required_options
+    end
+
+    private
+
+    def are_all_these_options_set?(options)
+      options.inject(true) {|bool, opt| bool && opt.is_set?}
+    end
+
+    def required_options
+      @hash.values.reject{|opt| !opt.required? }
     end
 
   end

--- a/lib/ns-options/options.rb
+++ b/lib/ns-options/options.rb
@@ -1,10 +1,11 @@
 require 'ns-options/option'
 
 module NsOptions
+
   class Options
 
-    def initialize(option_type=nil)
-      @option_type = option_type || :default
+    def initialize(handing=nil)
+      @handing = handing || :default
       @hash = Hash.new
     end
 
@@ -18,6 +19,9 @@ module NsOptions
 
     def add(*args)
       name, type_class, rules = NsOptions::Option.args(*args)
+      if @handing == :values && !rules.has_key?(:value)
+        rules[:value] = NsOptions::Option::PendingValue
+      end
 
       option = NsOptions::Option.new(name, type_class, rules)
       self[option.name] = option

--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -50,12 +50,14 @@ module NsOptions::Proxy
     # pass thru namespace methods to the proxied NAMESPACE handler
 
     def option(name, *args, &block)
+      # TODO: for values proxy, inject in a :value rule here
       __proxy_options__.option(name, *args, &block)
       NsOptions::ProxyMethod.new(self, name, 'an option').define($stdout, caller)
     end
     alias_method :opt, :option
 
     def namespace(name, *args, &block)
+      # TODO: for values proxy, inject in the :values flag here
       __proxy_options__.namespace(name, *args, &block)
       NsOptions::ProxyMethod.new(self, name, 'a namespace').define($stdout, caller)
     end

--- a/lib/ns-options/proxy_method.rb
+++ b/lib/ns-options/proxy_method.rb
@@ -39,9 +39,8 @@ module NsOptions
 
     private
 
-    # TODO: inherited hook to build_from and apply on the subclass root meth
     def proxy_meth_code
-      "def #{@name}(*args, &block); __proxy_options__.#{@name}; end"
+      "def #{@name}(*args, &block); __proxy_options__.#{@name}(*args, &block); end"
     end
 
     def not_recommended_meth_names

--- a/lib/ns-options/root_methods.rb
+++ b/lib/ns-options/root_methods.rb
@@ -45,12 +45,11 @@ module NsOptions
 
     private
 
-    # TODO: inherited hook to build_from and apply on the subclass root meth
     def class_meth_extension_code
       %{
         def #{@name}(*args, &block)
           unless @#{@name}
-            @#{@name} = NsOptions::Namespace.new('#{@name}', &block)
+            @#{@name} = NsOptions::Namespace.new('#{@name}', *args, &block)
             if respond_to?('superclass') && superclass &&
                superclass.respond_to?('#{@name}') &&
                superclass.#{@name}.kind_of?(NsOptions::Namespace)
@@ -66,7 +65,7 @@ module NsOptions
       %{
         def #{@name}(*args, &block)
           unless @#{@name}
-            @#{@name} = NsOptions::Namespace.new('#{@name}', &block)
+            @#{@name} = NsOptions::Namespace.new('#{@name}', *args, &block)
             @#{@name}.build_from(self.class.#{@name})
           end
           @#{@name}

--- a/test/unit/namespace_data_tests.rb
+++ b/test/unit/namespace_data_tests.rb
@@ -13,7 +13,7 @@ class NsOptions::NamespaceData
     subject { @data }
 
     should have_readers :ns, :name, :child_options, :child_namespaces
-    should have_imeths :has_option?, :has_namespace?, :required_set?
+    should have_imeths :has_option?, :has_namespace?, :value_option?, :required_set?
     should have_imeths :add_option, :get_option, :set_option
     should have_imeths :add_namespace, :get_namespace
     should have_imeths :to_hash, :each, :define, :build_from, :reset

--- a/test/unit/namespace_data_tests.rb
+++ b/test/unit/namespace_data_tests.rb
@@ -13,7 +13,7 @@ class NsOptions::NamespaceData
     subject { @data }
 
     should have_readers :ns, :name, :child_options, :child_namespaces
-    should have_imeths :has_option?, :has_namespace?, :value_option?, :required_set?
+    should have_imeths :has_option?, :has_namespace?, :required_set?
     should have_imeths :add_option, :get_option, :set_option
     should have_imeths :add_namespace, :get_namespace
     should have_imeths :to_hash, :apply, :each, :define, :build_from, :reset

--- a/test/unit/namespace_data_tests.rb
+++ b/test/unit/namespace_data_tests.rb
@@ -16,7 +16,7 @@ class NsOptions::NamespaceData
     should have_imeths :has_option?, :has_namespace?, :value_option?, :required_set?
     should have_imeths :add_option, :get_option, :set_option
     should have_imeths :add_namespace, :get_namespace
-    should have_imeths :to_hash, :each, :define, :build_from, :reset
+    should have_imeths :to_hash, :apply, :each, :define, :build_from, :reset
 
     should "know its namespace" do
       assert_equal @ns, subject.ns
@@ -109,12 +109,17 @@ class NsOptions::NamespaceData
       assert_equal(exp_hash, subject.to_hash)
     end
 
+    should "apply a given hash value to itself" do
+      subject.apply(@named_values)
+      assert_equal @named_values, subject.to_hash
+    end
+
   end
 
   class EachTests < HandlingTests
     desc "iterated with the each method"
     setup do
-      @ns.apply(@named_values)
+      subject.apply(@named_values)
       @exp = "".tap do |exp|
         subject.to_hash.each do |k,v|
           exp << "#{k}=#{v};"

--- a/test/unit/namespace_data_tests.rb
+++ b/test/unit/namespace_data_tests.rb
@@ -16,7 +16,7 @@ class NsOptions::NamespaceData
     should have_imeths :has_option?, :has_namespace?, :required_set?
     should have_imeths :add_option, :get_option, :set_option
     should have_imeths :add_namespace, :get_namespace
-    should have_imeths :to_hash, :apply, :each, :define, :build_from, :reset
+    should have_imeths :to_hash, :each, :define, :build_from, :reset
 
     should "know its namespace" do
       assert_equal @ns, subject.ns
@@ -109,17 +109,12 @@ class NsOptions::NamespaceData
       assert_equal(exp_hash, subject.to_hash)
     end
 
-    should "apply a given hash value to itself" do
-      subject.apply(@named_values)
-      assert_equal @named_values, subject.to_hash
-    end
-
   end
 
   class EachTests < HandlingTests
     desc "iterated with the each method"
     setup do
-      subject.apply(@named_values)
+      @ns.apply(@named_values)
       @exp = "".tap do |exp|
         subject.to_hash.each do |k,v|
           exp << "#{k}=#{v};"

--- a/test/unit/namespace_tests.rb
+++ b/test/unit/namespace_tests.rb
@@ -165,6 +165,33 @@ class NsOptions::Namespace
 
   end
 
+  class ApplyTests < BaseTests
+    setup do
+      @namespace.define do
+        option :first; option :second; option :third
+        namespace(:child_a) do
+          option(:fourth); option(:fifth)
+          namespace(:child_b) { option(:sixth) }
+        end
+      end
+
+      @named_values = {
+        :first => "1", :second => "2", :third => "3", :twenty_one => "21",
+        :child_a => {
+          :fourth => "4", :fifth => "5",
+          :child_b => { :sixth => "6" }
+        },
+        :child_c => { :what => "?" }
+      }
+    end
+
+    should "apply a given hash value to itself" do
+      subject.apply(@named_values)
+      assert_equal @named_values, subject.to_hash
+    end
+
+  end
+
   class EqualityTests < BaseTests
     desc "when compared for equality"
     setup do

--- a/test/unit/namespace_tests.rb
+++ b/test/unit/namespace_tests.rb
@@ -14,7 +14,7 @@ class NsOptions::Namespace
     should have_reader :__data__
     should have_imeths :option, :opt, :namespace, :ns
     should have_imeths :required_set?, :valid?
-    should have_imeths :has_option?, :has_namespace?, :value_option?
+    should have_imeths :has_option?, :has_namespace?
     should have_imeths :define, :build_from, :reset, :apply, :to_hash, :each
 
     should "contain its name key in its inspect output" do

--- a/test/unit/namespace_tests.rb
+++ b/test/unit/namespace_tests.rb
@@ -89,10 +89,6 @@ class NsOptions::Namespace
       @added_opt = @namespace.option('something', :value => 1234)
     end
 
-    should "NOT respond to a writer named after the option name" do
-      assert_not_responds_to :something=, subject
-    end
-
     should "NOT be writable through the defined writer" do
       err = begin
         subject.something = 'a'
@@ -100,7 +96,7 @@ class NsOptions::Namespace
         err
       end
 
-      assert_kind_of NsOptions::OptionWriteError, err
+      assert_kind_of NsOptions::Option::WriteError, err
       assert_includes "can't write the :value option `something'.", err.message
       assert_includes "test/unit/namespace_tests.rb:", err.backtrace.first
     end
@@ -112,7 +108,7 @@ class NsOptions::Namespace
         err
       end
 
-      assert_kind_of NsOptions::OptionWriteError, err
+      assert_kind_of NsOptions::Option::WriteError, err
       assert_includes "can't write the :value option `something'.", err.message
       assert_includes "test/unit/namespace_tests.rb:", err.backtrace.first
     end
@@ -169,8 +165,29 @@ class NsOptions::Namespace
       assert_responds_to :something, subject
     end
 
-    should "be return the namespace using the reader" do
+    should "return the namespace using the reader" do
       assert_equal subject.__data__.child_namespaces[:something], subject.something
+    end
+
+  end
+
+  class ValuesHandlingTests < BaseTests
+    desc "with `:values` handling"
+    setup do
+      @namespace = NsOptions::Namespace.new(@name, :values)
+    end
+
+    should "add options with a :value rule" do
+      subject.option('something')
+      assert_equal NsOptions::Option::PendingValue, subject.something
+    end
+
+    should "add namespaces with :values handling" do
+      @namespace.namespace('something') do
+        option :something_else
+      end
+
+      assert_equal NsOptions::Option::PendingValue, subject.something.something_else
     end
 
   end

--- a/test/unit/namespace_tests.rb
+++ b/test/unit/namespace_tests.rb
@@ -100,8 +100,8 @@ class NsOptions::Namespace
         err
       end
 
-      assert_kind_of NoMethodError, err
-      assert_includes "undefined method `something='", err.message
+      assert_kind_of NsOptions::OptionWriteError, err
+      assert_includes "can't write the :value option `something'.", err.message
       assert_includes "test/unit/namespace_tests.rb:", err.backtrace.first
     end
 
@@ -112,8 +112,8 @@ class NsOptions::Namespace
         err
       end
 
-      assert_kind_of ArgumentError, err
-      assert_includes "wrong number of arguments (3 for 0)", err.message
+      assert_kind_of NsOptions::OptionWriteError, err
+      assert_includes "can't write the :value option `something'.", err.message
       assert_includes "test/unit/namespace_tests.rb:", err.backtrace.first
     end
 

--- a/test/unit/namespaces_tests.rb
+++ b/test/unit/namespaces_tests.rb
@@ -12,17 +12,13 @@ class NsOptions::Namespaces
 
     should have_instance_methods :add, :get, :required_set?
 
-    should "be a kind of a hash" do
-      assert_kind_of Hash, subject
-    end
+    should "only use strings for keys (indifferent access)" do
+      subject['string_key'] = true
+      subject[:symbol_key]  = true
 
-    should "only use symbols for keys" do
-      subject["string_key"] = true
-      subject[:symbol_key] = true
-
-      assert_includes :string_key, subject.keys
-      assert_includes :symbol_key, subject.keys
-      assert_not_includes "string_key", subject.keys
+      assert_includes 'string_key', subject.keys
+      assert_includes 'symbol_key', subject.keys
+      assert_not_includes :string_key, subject.keys
     end
 
     should "get items" do

--- a/test/unit/namespaces_tests.rb
+++ b/test/unit/namespaces_tests.rb
@@ -52,4 +52,21 @@ class NsOptions::Namespaces
 
   end
 
+  class ValuesTests < AddTests
+    desc "with `:values` handling"
+    setup do
+      @namespaces = NsOptions::Namespaces.new :values
+    end
+
+    should "add namespaces that do :values handling" do
+      assert_nil subject[:a_name]
+      subject.add(:a_name)
+      assert subject[:a_name]
+
+      subject[:a_name].option('subopt')
+      assert_equal NsOptions::Option::PendingValue, subject[:a_name].subopt
+    end
+
+  end
+
 end

--- a/test/unit/option_tests.rb
+++ b/test/unit/option_tests.rb
@@ -64,6 +64,23 @@ class NsOptions::Option
 
   end
 
+  class ValueRuleTests < BaseTests
+    desc "using the :value rule"
+    setup do
+      @option = NsOptions::Option.new(:opt, :value => "something")
+    end
+
+    should "set the value based on the rule" do
+      assert_equal 'something', subject.value
+    end
+
+    should "NOT allow overwriting the value" do
+      assert_nothing_raised { subject.value = "overwritten" }
+      assert_equal 'something', subject.value
+    end
+
+  end
+
   class RequiredRuleTests < BaseTests
     desc "using the :required rule"
     setup do

--- a/test/unit/option_tests.rb
+++ b/test/unit/option_tests.rb
@@ -107,8 +107,30 @@ class NsOptions::Option
     end
 
     should "NOT allow overwriting the value" do
-      assert_nothing_raised { subject.value = "overwritten" }
-      assert_equal 'something', subject.value
+      assert_raises WriteError do
+        subject.value = "overwritten"
+      end
+    end
+
+  end
+
+  class PendingValueRuleTests < ValueRuleTests
+    desc "with PendingValue"
+    setup do
+      @option = NsOptions::Option.new(:opt, Object, :value => PendingValue)
+    end
+
+    should "set the value as pending" do
+      assert_equal PendingValue, subject.value
+    end
+
+    should "take the first value written as the immutable value of the option" do
+      subject.value = 'this is it'
+      assert_equal 'this is it', subject.value
+
+      assert_raises WriteError do
+        subject.value = 'over write this'
+      end
     end
 
   end

--- a/test/unit/option_tests.rb
+++ b/test/unit/option_tests.rb
@@ -7,9 +7,8 @@ class NsOptions::Option
   class BaseTests < Assert::Context
     desc "NsOptions::Option"
     setup do
-      @rules = { :default => "development" }
-      @args = [:stage, String, @rules]
-      @option = NsOptions::Option.new(*@args)
+      @rules  = { :default => "development" }
+      @option = NsOptions::Option.new(:stage, nil, @rules)
     end
     subject{ @option }
 
@@ -17,16 +16,20 @@ class NsOptions::Option
     should have_accessors :name, :value, :type_class, :rules
     should have_imeths :is_set?, :required?, :reset
 
-    should "have set the name" do
-      assert_equal "stage", subject.name
+    should "know its name" do
+      assert_equal :stage, subject.name
     end
 
-    should "have set the type class" do
-      assert_equal String, subject.type_class
+    should "know its type class" do
+      assert_equal Object, subject.type_class
     end
 
-    should "have set the rules" do
-      assert_equal(@rules, subject.rules)
+    should "know its rules" do
+      exp_rules = {
+        :default => "development",
+        :args => []
+      }
+      assert_equal exp_rules, subject.rules
     end
 
     should "not be required? by default" do
@@ -35,10 +38,39 @@ class NsOptions::Option
 
   end
 
+  class ParseArgsTests < BaseTests
+    desc "when parsing args"
+    setup do
+      @pname, @ptype_class, @prules  = NsOptions::Option.args(:stage, String, @rules)
+    end
+
+    should "parse the name arg and convert to a string" do
+      assert_equal "stage", @pname
+
+      @pname, @ptype_class, @prules = NsOptions::Option.args('test')
+      assert_equal 'test', @pname
+    end
+
+    should "parse the type_class arg and default it to Object" do
+      assert_equal String, @ptype_class
+
+      @pname, @ptype_class, @prules = NsOptions::Option.args('test')
+      assert_equal Object, @ptype_class
+    end
+
+    should "parse option rules arguments, defaulting to {:args => []}" do
+      assert_equal @rules, @prules
+
+      @pname, @ptype_class, @prules = NsOptions::Option.args('test')
+      assert_equal({:args => []}, @prules)
+    end
+
+  end
+
   class DefaultRuleTests < BaseTests
     desc "using the :default rule"
     setup do
-      @option = NsOptions::Option.new(:opt, :default => "something")
+      @option = NsOptions::Option.new(:opt, Object, :default => "something")
     end
 
     should "have defaulted value based on the rule" do
@@ -67,7 +99,7 @@ class NsOptions::Option
   class ValueRuleTests < BaseTests
     desc "using the :value rule"
     setup do
-      @option = NsOptions::Option.new(:opt, :value => "something")
+      @option = NsOptions::Option.new(:opt, Object, :value => "something")
     end
 
     should "set the value based on the rule" do
@@ -84,7 +116,7 @@ class NsOptions::Option
   class RequiredRuleTests < BaseTests
     desc "using the :required rule"
     setup do
-      @option = NsOptions::Option.new(:opt, :required => true)
+      @option = NsOptions::Option.new(:opt, Object, :required => true)
     end
 
     should "return true with a call to #required?" do
@@ -114,35 +146,6 @@ class NsOptions::Option
 
   end
 
-  class ParseArgsTests < BaseTests
-    desc "when parsing args"
-    setup do
-      @prules, @ptype_class, @pname = NsOptions::Option.args(*@args)
-    end
-
-    should "parse option rules arguments, defaulting to {:args => []}" do
-      assert_equal @rules, @prules
-
-      @prules, @ptype_class, @pname = NsOptions::Option.args('test')
-      assert_equal({:args => []}, @prules)
-    end
-
-    should "parse the name arg and convert to a string" do
-      assert_equal "stage", @pname
-
-      @prules, @ptype_class, @pname = NsOptions::Option.args('test')
-      assert_equal 'test', @pname
-    end
-
-    should "parse the type_class arg and default it to Object" do
-      assert_equal String, @ptype_class
-
-      @prules, @ptype_class, @pname = NsOptions::Option.args('test')
-      assert_equal Object, @ptype_class
-    end
-
-  end
-
   class IsSetTests < BaseTests
     desc "is_set method"
     setup do
@@ -154,7 +157,6 @@ class NsOptions::Option
 
       end
       @special = NsOptions::Option.new(:no_blank, @type_class)
-
       @boolean = NsOptions::Option.new(:boolean, NsOptions::Boolean)
     end
 
@@ -284,19 +286,6 @@ class NsOptions::Option
 
   end
 
-  class WithoutTypeClassTests < BaseTests
-    desc "without a type class provided"
-    setup do
-      @option = NsOptions::Option.new(:something, nil)
-    end
-    subject{ @option }
-
-    should "have default it to Object" do
-      assert_equal Object, subject.type_class
-    end
-
-  end
-
   class WithTypeClassArgErrorTests < BaseTests
     desc "setting a value with arg error"
     setup do
@@ -409,14 +398,14 @@ class NsOptions::Option
   class WithReturnValueTests < BaseTests
     setup do
       # test control values
-      @string    = NsOptions::Option.new(:string, String)
-      @symbol    = NsOptions::Option.new(:symbol, Symbol)
-      @integer   = NsOptions::Option.new(:integer, Integer)
-      @float     = NsOptions::Option.new(:float, Float)
-      @hash      = NsOptions::Option.new(:hash, Hash)
-      @array     = NsOptions::Option.new(:array, Array)
-      @proc      = NsOptions::Option.new(:proc, Proc)
-      @lazy_proc = NsOptions::Option.new(:lazy_proc)
+      @string    = NsOptions::Option.new :string,    String
+      @symbol    = NsOptions::Option.new :symbol,    Symbol
+      @integer   = NsOptions::Option.new :integer,   Integer
+      @float     = NsOptions::Option.new :float,     Float
+      @hash      = NsOptions::Option.new :hash,      Hash
+      @array     = NsOptions::Option.new :array,     Array
+      @proc      = NsOptions::Option.new :proc,      Proc
+      @lazy_proc = NsOptions::Option.new :lazy_proc, Object
 
       # custom return value
       class HostedAt
@@ -478,7 +467,6 @@ class NsOptions::Option
           self.args = args
         end
       end
-      @value = "amazing"
     end
 
     class AsArrayTests < WithArgsTests
@@ -486,11 +474,11 @@ class NsOptions::Option
       setup do
         @args = [ true, false, { :hash => "yes" } ]
         @option = NsOptions::Option.new(:something, @class, { :args => @args })
-        @option.value = @value
+        @option.value = "amazing"
       end
 
       should "pass the args to the type class with the value" do
-        expected = @args.dup.insert(0, @value)
+        expected = ["amazing", *@args]
         assert_equal expected, subject.value.args
       end
 
@@ -501,11 +489,11 @@ class NsOptions::Option
       setup do
         @args = lambda{ "something" }
         @option = NsOptions::Option.new(:something, @class, { :args => @args })
-        @option.value = @value
+        @option.value = "amazing"
       end
 
       should "pass the single value to the type class with the value" do
-        expected = [*@args].insert(0, @value)
+        expected = ["amazing", *@args]
         assert_equal expected, subject.value.args
       end
 
@@ -516,15 +504,31 @@ class NsOptions::Option
       setup do
         @args = nil
         @option = NsOptions::Option.new(:something, @class, { :args => @args })
-        @option.value = @value
+        @option.value = "amazing"
       end
 
-      should "just pass the value to the type class" do
-        expected = [@value]
+      should "just pass the value to the type class and that's it" do
+        expected = ["amazing"]
         assert_equal expected, subject.value.args
       end
 
     end
+
+    class AsEmptyArrayValueTests < WithArgsTests
+      desc "as an empty Array value"
+      setup do
+        @args = []
+        @option = NsOptions::Option.new(:something, @class, { :args => @args })
+        @option.value = "amazing"
+      end
+
+      should "just pass the value to the type class and that's it" do
+        expected = ["amazing"]
+        assert_equal expected, subject.value.args
+      end
+
+    end
+
   end
 
 end

--- a/test/unit/options_tests.rb
+++ b/test/unit/options_tests.rb
@@ -144,4 +144,21 @@ class NsOptions::Options
 
   end
 
+  class ValuesTests < BaseTests
+    desc "with `:values` handling"
+    setup do
+      @options = NsOptions::Options.new :values
+    end
+
+    should "add all options with a pending :value rule" do
+      opt = subject.add(:first, String)
+      exp_rules = {
+        :value => NsOptions::Option::PendingValue,
+        :args => []
+      }
+
+      assert_equal exp_rules, opt.rules
+    end
+  end
+
 end

--- a/test/unit/options_tests.rb
+++ b/test/unit/options_tests.rb
@@ -12,17 +12,13 @@ class NsOptions::Options
 
     should have_instance_method :add, :rm, :get, :set, :required_set?
 
-    should "be a Hash" do
-      assert_kind_of Hash, subject
-    end
+    should "only use strings for keys (indifferent access)" do
+      subject['string_key'] = true
+      subject[:symbol_key]  = true
 
-    should "only use symbols for keys" do
-      subject["string_key"] = true
-      subject[:symbol_key] = true
-
-      assert_includes :string_key, subject.keys
-      assert_includes :symbol_key, subject.keys
-      assert_not_includes "string_key", subject.keys
+      assert_includes 'string_key', subject.keys
+      assert_includes 'symbol_key', subject.keys
+      assert_not_includes :string_key, subject.keys
     end
 
   end


### PR DESCRIPTION
Specifying an option with the `:value` rule makes it immutable.

``` ruby
option :whatever, :value => 'idontcare'

thing.whatever           #=> 'idontcare'
thing.whatever = 'huh'   #=> NoMethodError ...
thing.whatever 'huh'     #=> ArgumentError ...
```

Addresses #57.
