### PR TITLE
remove `:require` rule alias for `:required`

### DIFF
--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -60,8 +60,7 @@ module NsOptions
     end
 
     def required?
-      # TODO: wat??
-      !!self.rules[:required] || !!self.rules[:require]
+      !!self.rules[:required]
     end
 
     def ==(other)

--- a/test/support/user.rb
+++ b/test/support/user.rb
@@ -7,8 +7,8 @@ class User
 
   options(:preferences) do
     option :home_url
-    option :show_messages,  NsOptions::Boolean, :require => true
-    option :font_size,      Integer,            :default => 12
+    option :show_messages,  NsOptions::Boolean, :required => true
+    option :font_size,      Integer,            :default  => 12
 
     namespace :view do
       option :color

--- a/test/system/user_tests.rb
+++ b/test/system/user_tests.rb
@@ -23,8 +23,8 @@ class User
     subject{ @class.preferences }
 
     should have_option :home_url
-    should have_option :show_messages,  NsOptions::Boolean, :require => true
-    should have_option :font_size,      Integer,            :default => 12
+    should have_option :show_messages,  NsOptions::Boolean, :required => true
+    should have_option :font_size,      Integer,            :default  => 12
 
     should have_namespace :view do
       option :color
@@ -45,8 +45,8 @@ class User
     subject { @a_sub_class.preferences }
 
     should have_option :home_url
-    should have_option :show_messages,  NsOptions::Boolean, :require => true
-    should have_option :font_size,      Integer,            :default => 12
+    should have_option :show_messages,  NsOptions::Boolean, :required => true
+    should have_option :font_size,      Integer,            :default  => 12
 
     should have_namespace :view do
       option :color
@@ -109,8 +109,8 @@ class User
     subject{ @instance.preferences }
 
     should have_option :home_url
-    should have_option :show_messages,  NsOptions::Boolean, :require => true
-    should have_option :font_size,      Integer,            :default => 12
+    should have_option :show_messages,  NsOptions::Boolean, :required => true
+    should have_option :font_size,      Integer,            :default  => 12
 
     should have_namespace :view do
       option :color
@@ -134,8 +134,8 @@ class User
     subject { @the_sub_class.preferences }
 
     should have_option :home_url
-    should have_option :show_messages,  NsOptions::Boolean, :require => true
-    should have_option :font_size,      Integer,            :default => 12
+    should have_option :show_messages,  NsOptions::Boolean, :required => true
+    should have_option :font_size,      Integer,            :default  => 12
 
     should have_namespace :view do
       option :color


### PR DESCRIPTION
I didn't even know this was in here.  It's not documented in the
README.  Wasn't _explicitly_ tested for (was used randomly in some
of the tests, so I guess it was implicitly tested).  I think the
value-added is low; let's remove the code debt.
