### PR TITLE
Handler defining same-named options and/or namespaces

### DIFF
--- a/lib/ns-options/namespace_data.rb
+++ b/lib/ns-options/namespace_data.rb
@@ -28,6 +28,8 @@ module NsOptions
     def add_option(*args)
       name = args.first
       opt  = NsOptions::Option.new(*NsOptions::Option.args(args, @option_type_class))
+
+      @child_namespaces.rm(name)
       @child_options.add(name, opt)
     end
 
@@ -36,6 +38,8 @@ module NsOptions
     def add_namespace(name, option_type_class=nil, &block)
       opt_type_class = option_type_class || @option_type_class
       ns = NsOptions::Namespace.new(name, opt_type_class, &block)
+
+      @child_options.rm(name)
       @child_namespaces.add(name, ns)
     end
 
@@ -134,7 +138,7 @@ module NsOptions
         rescue NsOptions::Option::CoerceError
           error! bt, err # reraise this exception with a sane backtrace
         end
-      else
+      else # namespace writer or unknown
         # raise a no meth err with a sane backtrace
         error! bt, NoMethodError.new("undefined method `#{meth}' for #{@ns.inspect}")
       end

--- a/lib/ns-options/namespaces.rb
+++ b/lib/ns-options/namespaces.rb
@@ -15,8 +15,9 @@ module NsOptions
     def each(*args, &block);   @hash.each(*args, &block);   end
     def empty?(*args, &block); @hash.empty?(*args, &block); end
 
-    def add(name, ns); self[name] = ns; end
-    def get(name);     self[name];      end
+    def add(name, ns); self[name] = ns;         end
+    def rm(name);      @hash.delete(name.to_s); end
+    def get(name);     self[name];              end
 
     def required_set?
       are_all_these_namespaces_set? @hash.values

--- a/lib/ns-options/options.rb
+++ b/lib/ns-options/options.rb
@@ -21,7 +21,7 @@ module NsOptions
     end
 
     def rm(name)
-      self[name] = nil
+      @hash.delete(name.to_s)
     end
 
     def get(name)

--- a/test/unit/namespace_data_tests.rb
+++ b/test/unit/namespace_data_tests.rb
@@ -281,4 +281,56 @@ class NsOptions::NamespaceData
 
   end
 
+  class SameNameTests < BaseTests
+
+    should "replace a same-named option when adding a new option" do
+      subject.add_option :something, String
+      assert subject.has_option? :something
+
+      subject.add_option :something, Fixnum, :default => 10
+      assert subject.has_option? :something
+
+      opt = subject.child_options[:something]
+      assert_equal Fixnum, opt.type_class
+      assert_equal 10,     opt.rules[:default]
+    end
+
+    should "replace a same-named option when adding a new namespace" do
+      subject.add_option :something, String
+      assert subject.has_option? :something
+
+      subject.add_namespace :something
+      assert_not subject.has_option?    :something
+      assert     subject.has_namespace? :something
+
+      assert_equal Hash.new, subject.child_namespaces[:something].to_hash
+    end
+
+    should "replace a same-named namespace when adding a new namespace" do
+      subject.add_namespace :something do
+        option :a, :default => 10
+      end
+      assert subject.has_namespace? :something
+      assert_equal({:a => 10}, subject.child_namespaces[:something].to_hash)
+
+      subject.add_namespace :something
+      assert subject.has_namespace? :something
+      assert_equal Hash.new, subject.child_namespaces[:something].to_hash
+    end
+
+    should "replace a same-named namespace when adding a new option" do
+      subject.add_namespace :something
+      assert subject.has_namespace? :something
+
+      subject.add_option :something, Fixnum, :default => 10
+      assert_not subject.has_namespace? :something
+      assert     subject.has_option?    :something
+
+      opt = subject.child_options[:something]
+      assert_equal Fixnum, opt.type_class
+      assert_equal 10,     opt.rules[:default]
+    end
+
+  end
+
 end

--- a/test/unit/namespaces_tests.rb
+++ b/test/unit/namespaces_tests.rb
@@ -12,7 +12,7 @@ class NsOptions::Namespaces
 
     should have_accessor :[]
     should have_imeths :keys, :each, :empty?
-    should have_imeths :add, :get, :required_set?
+    should have_imeths :add, :rm, :get, :required_set?
 
     should "only use strings for keys (indifferent access)" do
       subject['string_key'] = true
@@ -50,6 +50,28 @@ class NsOptions::Namespaces
     should "return the option added" do
       added_ns = subject.add(:a_name, NsOptions::Namespace.new(:a_name))
       assert_kind_of NsOptions::Namespace, added_ns
+    end
+
+  end
+
+  class RmTests < BaseTests
+    desc "rm method"
+    setup do
+      @namespaces.add(:my_string)
+    end
+
+    should "remove the option definition from the collection" do
+      assert subject[:my_string]
+
+      subject.rm(:my_string)
+      assert_nil subject[:my_string]
+    end
+
+    should "should work with both string and symbol names" do
+      assert subject[:my_string]
+
+      subject.rm('my_string')
+      assert_nil subject[:my_string]
     end
 
   end

--- a/test/unit/options_tests.rb
+++ b/test/unit/options_tests.rb
@@ -62,12 +62,14 @@ class NsOptions::Options
 
     should "remove the option definition from the collection" do
       assert subject[:my_string]
+
       subject.rm(:my_string)
       assert_nil subject[:my_string]
     end
 
     should "should work with both string and symbol names" do
       assert subject[:my_string]
+
       subject.rm('my_string')
       assert_nil subject[:my_string]
     end


### PR DESCRIPTION
No matter the permutation (opt-over-ns or ns-over-opt), when adding
an option, remove any namespaces with the same name that happen to
exist and vice-versa when adding a namespace.

This ensures that only one option or namespace exists for a given
name at any time - the last one to be defined/added.  This also
removes the subjective task of determining which takes precedent
when a named thing is requested and there is both an option and a
namespace with the requested name.

The net effect is an intuitive experience for the user: the last thing
added with the name {name} will be return when requesting {name}.

Closes #58.
