### PR TITLE
`option_type_class` setting for namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ App.settings.grouped_stuff.something # => 1
 
 ### Less Verbose Definitions
 
-As an alternative to the above definition syntax, you can use an alternate less-verbose syntax:
+As an alternative to the above definition syntax, you can use a less-verbose syntax:
 
 * `opts` for `options`
 * `opt` for `option`
@@ -162,6 +162,44 @@ App.setting.stage = nil
 ```
 
 For type coercion to work, your type class's initializer must work given only a single argument.
+
+### Default Type Classes
+
+```ruby
+class MyCustomFixNum < Struct.new(:num); end
+
+options :settings do
+  option_type_class Fixnum
+
+  option :opt1, :default => 1
+  option :opt2, :default => 2
+  option :opt3, MyCustomFixNum, :default => 3
+end
+
+settings.opt1.class  #=> Fixnum
+settings.opt3.class  #=> Fixnum
+settings.opt3.class  #=> MyCustomFixNum
+```
+
+By default, NsOptions will use `Object` for an option's type class if none is specified.  You can override this on a per-namespaces basis using the `option_type_class` method.  Call this and all options will be defined using the given class by default.
+
+Note, this setting applies recursively, so all child namespaces honor it as well.  You can override this by specifying a new type class on your child namespaces.
+
+```ruby
+# you can use an abbreviated syntax
+#...
+options :settings do
+  opt_type_class Fixnum
+
+  option :opt1, :default => 1
+#...
+
+# you can also pass in the option type class when defining the ns
+#...
+options :settings, Fixnum do
+  option :opt1, :default => 1
+#...
+```
 
 ### Ruby Classes As A Type Class
 

--- a/lib/ns-options/assert_macros.rb
+++ b/lib/ns-options/assert_macros.rb
@@ -40,7 +40,7 @@ module NsOptions::AssertMacros
 
     def have_option(*args)
       called_from = caller.first
-      opt_name, type_class, rules = NsOptions::Option.args(*args)
+      opt_name, type_class, rules = NsOptions::Option.args(args)
       test_name = [
         "have an option: '#{opt_name}'",
         "of type '#{type_class}'",

--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -7,9 +7,9 @@ module NsOptions
 
     attr_reader :__name__, :__data__
 
-    def initialize(name, &block)
+    def initialize(name, option_type_class=nil, &block)
       @__name__ = name
-      @__data__ = NamespaceData.new(self)
+      @__data__ = NamespaceData.new(self, option_type_class || Object)
       @__data__.define(&block)
     end
 
@@ -24,6 +24,12 @@ module NsOptions
       @__data__.add_namespace(name, *args, &block)
     end
     alias_method :ns, :namespace
+
+    def option_type_class(*args)
+      return @__data__.option_type_class if args.empty?
+      @__data__.set_option_type_class(*args)
+    end
+    alias_method :opt_type_class, :option_type_class
 
     def has_option?(name);    @__data__.has_option?(name);    end
     def has_namespace?(name); @__data__.has_namespace?(name); end

--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -5,10 +5,11 @@ module NsOptions
 
   class Namespace
 
-    attr_reader :__data__
+    attr_reader :__name__, :__data__
 
     def initialize(name, &block)
-      @__data__ = NamespaceData.new(self, name)
+      @__name__ = name
+      @__data__ = NamespaceData.new(self)
       @__data__.define(&block)
     end
 
@@ -53,7 +54,7 @@ module NsOptions
     end
 
     def inspect(*args)
-      "#<#{self.class}:#{'0x%x' % (self.object_id << 1)}:#{@__data__.name} #{to_hash.inspect}>"
+      "#<#{self.class}:#{'0x%x' % (self.object_id << 1)}:#{@__name__} #{to_hash.inspect}>"
     end
 
   end

--- a/lib/ns-options/namespace_data.rb
+++ b/lib/ns-options/namespace_data.rb
@@ -21,12 +21,16 @@ module NsOptions
     def has_option?(name);     !!@child_options[name];         end
     def get_option(name);      @child_options.get(name);       end
     def set_option(name, val); @child_options.set(name, val);  end
-    def add_option(*args);     @child_options.add(*args);      end
+    def add_option(name, *args)
+      opt = NsOptions::Option.new(*NsOptions::Option.args(name, *args))
+      @child_options.add(name, opt)
+    end
 
     def has_namespace?(name);  !!@child_namespaces[name];      end
     def get_namespace(name);   @child_namespaces.get(name);    end
     def add_namespace(name, *args, &block)
-      @child_namespaces.add(name, *args, &block)
+      ns = NsOptions::Namespace.new(name,*args, &block)
+      @child_namespaces.add(name, ns)
     end
 
     # recursively build a hash representation of the namespace, using symbols

--- a/lib/ns-options/namespace_data.rb
+++ b/lib/ns-options/namespace_data.rb
@@ -21,8 +21,9 @@ module NsOptions
     def has_option?(name);     !!@child_options[name];         end
     def get_option(name);      @child_options.get(name);       end
     def set_option(name, val); @child_options.set(name, val);  end
-    def add_option(name, *args)
-      opt = NsOptions::Option.new(*NsOptions::Option.args(name, *args))
+    def add_option(*args)
+      name = args.first
+      opt  = NsOptions::Option.new(*NsOptions::Option.args(args))
       @child_options.add(name, opt)
     end
 

--- a/lib/ns-options/namespace_data.rb
+++ b/lib/ns-options/namespace_data.rb
@@ -5,10 +5,10 @@ module NsOptions
 
   class NamespaceData
 
-    attr_reader :ns, :name, :child_options, :child_namespaces
+    attr_reader :ns, :child_options, :child_namespaces
 
-    def initialize(ns, name)
-      @ns, @name = ns, name
+    def initialize(ns)
+      @ns = ns
       @child_namespaces = NsOptions::Namespaces.new
       @child_options    = NsOptions::Options.new
     end

--- a/lib/ns-options/namespace_data.rb
+++ b/lib/ns-options/namespace_data.rb
@@ -5,12 +5,12 @@ module NsOptions
 
   class NamespaceData
 
-    attr_reader :ns, :child_options, :child_namespaces
+    attr_reader :ns, :option_type_class, :child_options, :child_namespaces
 
-    def initialize(ns)
-      @ns = ns
-      @child_namespaces = NsOptions::Namespaces.new
-      @child_options    = NsOptions::Options.new
+    def initialize(ns, option_type_class)
+      @ns, @option_type_class = ns, option_type_class
+      @child_namespaces       = NsOptions::Namespaces.new
+      @child_options          = NsOptions::Options.new
     end
 
     # Recursively check if options that were defined as :required have been set.
@@ -18,19 +18,24 @@ module NsOptions
       @child_options.required_set? && @child_namespaces.required_set?
     end
 
+    def set_option_type_class(value)
+      @option_type_class = value
+    end
+
     def has_option?(name);     !!@child_options[name];         end
     def get_option(name);      @child_options.get(name);       end
     def set_option(name, val); @child_options.set(name, val);  end
     def add_option(*args)
       name = args.first
-      opt  = NsOptions::Option.new(*NsOptions::Option.args(args))
+      opt  = NsOptions::Option.new(*NsOptions::Option.args(args, @option_type_class))
       @child_options.add(name, opt)
     end
 
     def has_namespace?(name);  !!@child_namespaces[name];      end
     def get_namespace(name);   @child_namespaces.get(name);    end
-    def add_namespace(name, *args, &block)
-      ns = NsOptions::Namespace.new(name,*args, &block)
+    def add_namespace(name, option_type_class=nil, &block)
+      opt_type_class = option_type_class || @option_type_class
+      ns = NsOptions::Namespace.new(name, opt_type_class, &block)
       @child_namespaces.add(name, ns)
     end
 
@@ -74,9 +79,12 @@ module NsOptions
     end
 
     def build_from(other_ns_data)
+      set_option_type_class(other_ns_data.option_type_class)
+
       other_ns_data.child_options.each do |name, opt|
         add_option(name, opt.type_class, opt.rules)
       end
+
       other_ns_data.child_namespaces.each do |name, ns|
         new_ns = add_namespace(name)
         new_ns.build_from(ns)

--- a/lib/ns-options/namespaces.rb
+++ b/lib/ns-options/namespaces.rb
@@ -15,11 +15,8 @@ module NsOptions
     def each(*args, &block);   @hash.each(*args, &block);   end
     def empty?(*args, &block); @hash.empty?(*args, &block); end
 
-    def add(name, *args, &block)
-      self[name] = NsOptions::Namespace.new(name, *args, &block)
-    end
-
-    def get(name); self[name]; end
+    def add(name, ns); self[name] = ns; end
+    def get(name);     self[name];      end
 
     def required_set?
       are_all_these_namespaces_set? @hash.values

--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -10,7 +10,7 @@ module NsOptions
     end
 
     def self.rules(rules)
-      # for any given `:args` rule into an array
+      # make sure any given `:args` rule is an array
       (rules || {}).tap do |r|
         r[:args] = (r[:args] ? [*r[:args]] : [])
       end

--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -16,11 +16,11 @@ module NsOptions
       end
     end
 
-    def self.args(args)
+    def self.args(args, default_type_class=nil)
       [ self.rules(args.last.kind_of?(::Hash) ? args.pop : {}),
         # if a nil type_class is given, just use Object
         # this makes the option accept any value with no type coercion
-        (args[1] || Object),
+        (args[1] || default_type_class || Object),
         args[0].to_s
       ].reverse
     end

--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -10,12 +10,13 @@ module NsOptions
     end
 
     def self.rules(rules)
+      # for any given `:args` rule into an array
       (rules || {}).tap do |r|
         r[:args] = (r[:args] ? [*r[:args]] : [])
       end
     end
 
-    def self.args(*args)
+    def self.args(args)
       [ self.rules(args.last.kind_of?(::Hash) ? args.pop : {}),
         # if a nil type_class is given, just use Object
         # this makes the option accept any value with no type coercion

--- a/lib/ns-options/options.rb
+++ b/lib/ns-options/options.rb
@@ -16,9 +16,8 @@ module NsOptions
     def each(*args, &block);   @hash.each(*args, &block);   end
     def empty?(*args, &block); @hash.empty?(*args, &block); end
 
-    def add(*args)
-      option = NsOptions::Option.new(*NsOptions::Option.args(*args))
-      self[option.name] = option
+    def add(name, opt)
+      self[name] = opt
     end
 
     def rm(name)

--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -70,7 +70,7 @@ module NsOptions::Proxy
     def valid?(*args, &block);        __proxy_options__.valid?(*args, &block);        end
 
     def inspect(*args, &block)
-      "#<#{self.class}:#{'0x%x' % (self.object_id << 1)}:#{__proxy_options__.__data__.name} #{__proxy_options__.to_hash.inspect}>"
+      "#<#{self.class}:#{'0x%x' % (self.object_id << 1)}:#{__proxy_options__.__name__} #{__proxy_options__.to_hash.inspect}>"
     end
 
     # for everything else, send to the proxied NAMESPACE handler

--- a/lib/ns-options/root_methods.rb
+++ b/lib/ns-options/root_methods.rb
@@ -9,9 +9,9 @@ module NsOptions
     # class level namespace but with an identical definition
 
     def initialize(define_on, name)
-      @define_on, @name = define_on, name
+      @define_on, @name     = define_on, name
       @class_meth_extension = Module.new
-      @instance_meth_mixin = Module.new
+      @instance_meth_mixin  = Module.new
     end
 
     def define_on_class?
@@ -45,6 +45,7 @@ module NsOptions
 
     private
 
+    # TODO: be able to call with block over and over
     def class_meth_extension_code
       %{
         def #{@name}(*args, &block)
@@ -61,6 +62,7 @@ module NsOptions
       }
     end
 
+    # TODO: be able to call with block over and over
     def instance_meth_mixin_code
       %{
         def #{@name}(*args, &block)

--- a/test/support/type_class_proxy.rb
+++ b/test/support/type_class_proxy.rb
@@ -1,0 +1,29 @@
+require 'ns-options'
+
+class DefaultTypeClass < Struct.new(:value); end
+
+class TypeClassProxy
+  include NsOptions::Proxy
+
+  option_type_class DefaultTypeClass
+
+  opt :value1             # test that DefaultTypeClass is used
+
+  ns :more do
+    opt :more1            # that it is used recursively
+  end
+
+  ns :strings do
+    opt_type_class String
+    opt :string1          # that it can be over written
+  end
+
+  ns :objs, Object do
+    type_class Object
+    opt :obj1             # and that it can be reset to the default
+  end
+
+end
+
+class InheritedTypeClassProxy < TypeClassProxy; end
+class DoubleInheritedTypeClassProxy < InheritedTypeClassProxy; end

--- a/test/system/type_class_proxy_tests.rb
+++ b/test/system/type_class_proxy_tests.rb
@@ -1,0 +1,108 @@
+require 'assert'
+
+require 'ns-options/assert_macros'
+require 'test/support/type_class_proxy'
+
+class TypeClassProxyTests < Assert::Context
+  include NsOptions::AssertMacros
+
+  desc "a proxy using option_type_class"
+  setup do
+    set_proxy_for_tests(TypeClassProxy)
+  end
+
+  def set_proxy_for_tests(proxy_class)
+    @proxy = proxy_class
+    proxy_class.value1          = 10
+    proxy_class.more.more1      = 10
+    proxy_class.strings.string1 = 10
+    proxy_class.objs.obj1       = Object.new
+  end
+
+  should "use the option type class for its options" do
+    assert_kind_of DefaultTypeClass, @proxy.value1
+    assert_equal   10, @proxy.value1.value
+  end
+
+  should "use the option type class for its namespaces" do
+    assert_equal DefaultTypeClass, @proxy.more.option_type_class
+  end
+
+  should "recursively use the option type class" do
+    assert_kind_of DefaultTypeClass, @proxy.more.more1
+  end
+
+  should "allow the recursive option type class to be overridden" do
+    assert_equal   String, @proxy.strings.option_type_class
+    assert_kind_of String, @proxy.strings.string1
+  end
+
+  should "allow the recursive option type class to be reset" do
+    assert_equal   Object, @proxy.objs.option_type_class
+    assert_kind_of Object, @proxy.objs.obj1
+  end
+
+end
+
+class InheritedTypeClassProxyTests < TypeClassProxyTests
+  desc "that inherits from another"
+  setup do
+    set_proxy_for_tests(InheritedTypeClassProxy)
+  end
+
+  should "use the option type class for its options" do
+    assert_kind_of DefaultTypeClass, @proxy.value1
+    assert_equal   10, @proxy.value1.value
+  end
+
+  should "use the option type class for its namespaces" do
+    assert_equal DefaultTypeClass, @proxy.more.option_type_class
+  end
+
+  should "recursively use the option type class" do
+    assert_kind_of DefaultTypeClass, @proxy.more.more1
+  end
+
+  should "allow the recursive option type class to be overridden" do
+    assert_equal   String, @proxy.strings.option_type_class
+    assert_kind_of String, @proxy.strings.string1
+  end
+
+  should "allow the recursive option type class to be reset" do
+    assert_equal   Object, @proxy.objs.option_type_class
+    assert_kind_of Object, @proxy.objs.obj1
+  end
+
+end
+
+class DoubleInheritedTypeClassProxyTests < TypeClassProxyTests
+  desc "that inherits from another that inherits from another"
+  setup do
+    set_proxy_for_tests(DoubleInheritedTypeClassProxy)
+  end
+
+  should "use the option type class for its options" do
+    assert_kind_of DefaultTypeClass, @proxy.value1
+    assert_equal   10, @proxy.value1.value
+  end
+
+  should "use the option type class for its namespaces" do
+    assert_equal DefaultTypeClass, @proxy.more.option_type_class
+  end
+
+  should "recursively use the option type class" do
+    assert_kind_of DefaultTypeClass, @proxy.more.more1
+  end
+
+  should "allow the recursive option type class to be overridden" do
+    assert_equal   String, @proxy.strings.option_type_class
+    assert_kind_of String, @proxy.strings.string1
+  end
+
+  should "allow the recursive option type class to be reset" do
+    assert_equal   Object, @proxy.objs.option_type_class
+    assert_kind_of Object, @proxy.objs.obj1
+  end
+
+end
+

--- a/test/unit/namespace_data_tests.rb
+++ b/test/unit/namespace_data_tests.rb
@@ -12,7 +12,7 @@ class NsOptions::NamespaceData
     end
     subject { @data }
 
-    should have_readers :ns, :name, :child_options, :child_namespaces
+    should have_readers :ns, :child_options, :child_namespaces
     should have_imeths :has_option?, :has_namespace?, :required_set?
     should have_imeths :add_option, :get_option, :set_option
     should have_imeths :add_namespace, :get_namespace
@@ -20,10 +20,6 @@ class NsOptions::NamespaceData
 
     should "know its namespace" do
       assert_equal @ns, subject.ns
-    end
-
-    should "know its name" do
-      assert_equal 'thing', subject.name
     end
 
     should "know its child options" do

--- a/test/unit/namespace_data_tests.rb
+++ b/test/unit/namespace_data_tests.rb
@@ -12,14 +12,20 @@ class NsOptions::NamespaceData
     end
     subject { @data }
 
-    should have_readers :ns, :child_options, :child_namespaces
-    should have_imeths :has_option?, :has_namespace?, :required_set?
-    should have_imeths :add_option, :get_option, :set_option
-    should have_imeths :add_namespace, :get_namespace
-    should have_imeths :to_hash, :apply, :each, :define, :build_from, :reset
+    should have_readers :ns, :option_type_class
+    should have_readers :child_options, :child_namespaces
+    should have_imeths  :has_option?, :has_namespace?, :required_set?
+    should have_imeths  :add_option, :get_option, :set_option
+    should have_imeths  :add_namespace, :get_namespace
+    should have_imeths  :set_option_type_class
+    should have_imeths  :to_hash, :apply, :each, :define, :build_from, :reset
 
     should "know its namespace" do
       assert_equal @ns, subject.ns
+    end
+
+    should "know its type class" do
+      assert_equal Object, subject.option_type_class
     end
 
     should "know its child options" do
@@ -32,9 +38,25 @@ class NsOptions::NamespaceData
       assert_empty subject.child_namespaces
     end
 
+    should "be able to change its option_type_class" do
+      assert_equal Object, subject.option_type_class
+      subject.set_option_type_class(Fixnum)
+
+      assert_equal Fixnum, subject.option_type_class
+    end
+
     should "add options" do
       an_option = subject.add_option 'an_option'
+
       assert_equal an_option, subject.child_options['an_option']
+      assert_equal Object, an_option.type_class
+    end
+
+    should "add options with its type class" do
+      subject.set_option_type_class(Fixnum)
+      an_option = subject.add_option 'an_option'
+
+      assert_equal Fixnum, an_option.type_class
     end
 
     should "get option values" do
@@ -55,6 +77,17 @@ class NsOptions::NamespaceData
     should "add namespaces" do
       a_namespace = subject.add_namespace 'a_namespace'
       assert_equal a_namespace, subject.child_namespaces['a_namespace']
+
+      a_ns_data   = a_namespace.__data__
+      assert_equal Object, a_ns_data.option_type_class
+    end
+
+    should "add namespaces with its type class" do
+      subject.set_option_type_class(Fixnum)
+      a_namespace = subject.add_namespace 'a_namespace'
+      a_ns_data   = subject.child_namespaces['a_namespace'].__data__
+
+      assert_equal Fixnum, a_ns_data.option_type_class
     end
 
     should "get namespaces" do

--- a/test/unit/namespace_tests.rb
+++ b/test/unit/namespace_tests.rb
@@ -11,11 +11,15 @@ class NsOptions::Namespace
     end
     subject{ @namespace }
 
-    should have_reader :__data__
+    should have_reader :__name__, :__data__
     should have_imeths :option, :opt, :namespace, :ns
     should have_imeths :required_set?, :valid?
     should have_imeths :has_option?, :has_namespace?
     should have_imeths :define, :build_from, :reset, :apply, :to_hash, :each
+
+    should "know its name" do
+      assert_equal @name, subject.__name__
+    end
 
     should "contain its name key in its inspect output" do
       assert_included ":something", subject.inspect
@@ -96,7 +100,7 @@ class NsOptions::Namespace
 
       ns = subject.something
       assert_kind_of NsOptions::Namespace, ns
-      assert_equal 'something', ns.__data__.name
+      assert_equal 'something', ns.__name__
       assert ns.has_option? :something_else
     end
 

--- a/test/unit/namespace_tests.rb
+++ b/test/unit/namespace_tests.rb
@@ -13,6 +13,7 @@ class NsOptions::Namespace
 
     should have_reader :__name__, :__data__
     should have_imeths :option, :opt, :namespace, :ns
+    should have_imeths :option_type_class, :opt_type_class
     should have_imeths :required_set?, :valid?
     should have_imeths :has_option?, :has_namespace?
     should have_imeths :define, :build_from, :reset, :apply, :to_hash, :each
@@ -27,6 +28,15 @@ class NsOptions::Namespace
 
     should "contain its to_hash representation in its inspect output" do
       assert_included subject.to_hash.inspect, subject.inspect
+    end
+
+    should "know its option type class" do
+      assert_equal Object, subject.option_type_class
+    end
+
+    should "set its option type class" do
+      subject.option_type_class(String)
+      assert_equal String, subject.option_type_class
     end
 
   end

--- a/test/unit/namespaces_tests.rb
+++ b/test/unit/namespaces_tests.rb
@@ -37,18 +37,18 @@ class NsOptions::Namespaces
 
     should "add namespaces" do
       assert_nil subject[:a_name]
-      subject.add(:a_name)
+      subject.add(:a_name, NsOptions::Namespace.new(:a_name))
       assert subject[:a_name]
     end
 
     should "should work with both string and symbol names" do
       assert_nil subject[:a_name]
-      subject.add('a_name')
+      subject.add('a_name', NsOptions::Namespace.new('a_name'))
       assert subject[:a_name]
     end
 
     should "return the option added" do
-      added_ns = subject.add(:a_name)
+      added_ns = subject.add(:a_name, NsOptions::Namespace.new(:a_name))
       assert_kind_of NsOptions::Namespace, added_ns
     end
 

--- a/test/unit/option_tests.rb
+++ b/test/unit/option_tests.rb
@@ -58,6 +58,13 @@ class NsOptions::Option
       assert_equal Object, @ptype_class
     end
 
+    should "parse the type_class arg and default it to a given default type class" do
+      assert_equal String, @ptype_class
+
+      @pname, @ptype_class, @prules = NsOptions::Option.args(['test'], Fixnum)
+      assert_equal Fixnum, @ptype_class
+    end
+
     should "parse option rules arguments, defaulting to {:args => []}" do
       assert_equal @rules, @prules
 

--- a/test/unit/option_tests.rb
+++ b/test/unit/option_tests.rb
@@ -41,27 +41,27 @@ class NsOptions::Option
   class ParseArgsTests < BaseTests
     desc "when parsing args"
     setup do
-      @pname, @ptype_class, @prules  = NsOptions::Option.args(:stage, String, @rules)
+      @pname, @ptype_class, @prules  = NsOptions::Option.args([:stage, String, @rules])
     end
 
     should "parse the name arg and convert to a string" do
       assert_equal "stage", @pname
 
-      @pname, @ptype_class, @prules = NsOptions::Option.args('test')
+      @pname, @ptype_class, @prules = NsOptions::Option.args(['test'])
       assert_equal 'test', @pname
     end
 
     should "parse the type_class arg and default it to Object" do
       assert_equal String, @ptype_class
 
-      @pname, @ptype_class, @prules = NsOptions::Option.args('test')
+      @pname, @ptype_class, @prules = NsOptions::Option.args(['test'])
       assert_equal Object, @ptype_class
     end
 
     should "parse option rules arguments, defaulting to {:args => []}" do
       assert_equal @rules, @prules
 
-      @pname, @ptype_class, @prules = NsOptions::Option.args('test')
+      @pname, @ptype_class, @prules = NsOptions::Option.args(['test'])
       assert_equal({:args => []}, @prules)
     end
 

--- a/test/unit/options_tests.rb
+++ b/test/unit/options_tests.rb
@@ -30,23 +30,23 @@ class NsOptions::Options
 
     should "add options" do
       assert_nil subject[:my_string]
-      subject.add(:my_string)
+      subject.add(:my_string, NsOptions::Option.new(:my_string))
       assert subject[:my_string]
     end
 
     should "should work with both string and symbol names" do
       assert_nil subject[:my_string]
-      subject.add('my_string')
+      subject.add('my_string', NsOptions::Option.new('my_string'))
       assert subject[:my_string]
     end
 
     should "return the option added" do
-      added_opt = subject.add(:something)
+      added_opt = subject.add(:something, NsOptions::Option.new(:something))
       assert_kind_of NsOptions::Option, added_opt
     end
 
     should "build options with args when adding" do
-      subject.add(:my_float, Float, { :default => 1.0 })
+      subject.add(:my_float, NsOptions::Option.new(:my_float, Float, :default => 1.0))
 
       assert_equal Float, subject[:my_float].type_class
       assert_equal 1.0,   subject[:my_float].rules[:default]
@@ -57,7 +57,7 @@ class NsOptions::Options
   class RmTests < BaseTests
     desc "rm method"
     setup do
-      @options.add(:my_string)
+      @options.add(:my_string, NsOptions::Option.new(:my_string))
     end
 
     should "remove the option definition from the collection" do
@@ -77,7 +77,8 @@ class NsOptions::Options
   class GetTests < BaseTests
     desc "get method"
     setup do
-      @options.add(:my_string, { :default => "something" })
+      opt = NsOptions::Option.new(:my_string, Object, :default => "something")
+      @options.add(:my_string, opt)
     end
 
     should "return the named option value" do
@@ -93,7 +94,7 @@ class NsOptions::Options
   class SetTests < BaseTests
     desc "set method"
     setup do
-      @options.add(:my_string)
+      @options.add(:my_string, NsOptions::Option.new(:my_string))
     end
 
     should "set option values" do
@@ -115,9 +116,9 @@ class NsOptions::Options
   class RequiredSetTests < BaseTests
     desc "required_set? method"
     setup do
-      @options.add(:first, String, { :require => true })
-      @options.add(:second, String, { :required => true })
-      @options.add(:third, String)
+      @options.add(:first,  NsOptions::Option.new(:first,  String, :required => true))
+      @options.add(:second, NsOptions::Option.new(:second, String, :required => true))
+      @options.add(:third,  NsOptions::Option.new(:third,  String))
     end
 
     should "return true when all required options are set" do

--- a/test/unit/proxy_tests.rb
+++ b/test/unit/proxy_tests.rb
@@ -174,6 +174,7 @@ module NsOptions::Proxy
     setup do
       @a_super_class = Class.new do
         include NsOptions::Proxy
+        option_type_class Fixnum
 
         option :test
         namespace(:other) { option :stuff }
@@ -186,6 +187,11 @@ module NsOptions::Proxy
       assert a_sub_class.has_option? :test
       assert a_sub_class.has_namespace? :other
       assert a_sub_class.other.has_option? :stuff
+
+      a_sub_ns_data = a_sub_class.__proxy_options__.__data__
+      assert_equal Fixnum, a_sub_ns_data.option_type_class
+      other_ns_data = a_sub_class.other.__data__
+      assert_equal Fixnum, other_ns_data.option_type_class
     end
 
   end

--- a/test/unit/root_methods_tests.rb
+++ b/test/unit/root_methods_tests.rb
@@ -102,7 +102,7 @@ class NsOptions::RootMethods
     setup do
       @rm = NsOptions::RootMethods.new(@a_super_class = Class.new, 'a_ns')
       @rm.define
-      @a_super_class.a_ns do
+      @a_super_class.a_ns Fixnum do
         option :test
         namespace(:other) { option :stuff }
       end
@@ -114,6 +114,11 @@ class NsOptions::RootMethods
       assert a_sub_class.a_ns.has_option? :test
       assert a_sub_class.a_ns.has_namespace? :other
       assert a_sub_class.a_ns.other.has_option? :stuff
+
+      a_sub_ns_data = a_sub_class.a_ns.__data__
+      assert_equal Fixnum, a_sub_ns_data.option_type_class
+      other_ns_data = a_sub_class.a_ns.other.__data__
+      assert_equal Fixnum, other_ns_data.option_type_class
     end
 
   end


### PR DESCRIPTION
By default, NsOptions will use `Object` for an options type class if
none is specified.  You can override this on a per-namespaces basis
using the `type_class` method.  Call this and all options will be
defined using the given type class by default.

Note, this setting applies recursively, so all child namespaces honor
it as well.  You can override this by specifying a new type class on
your child namespaces.

Closes #59.
