### PR TITLE
build Array type-cast options using `Array.new([*value])`

### DIFF
--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -90,13 +90,15 @@ module NsOptions
       return value if no_coercing_needed?(value)
 
       begin
-        if [ Integer, Float, String ].include?(self.type_class)
+        if [ ::Integer, ::Float, ::String ].include?(self.type_class)
           # ruby type conversion, i.e. String(1)
           Object.send(self.type_class.to_s, value)
-        elsif self.type_class == Symbol
+        elsif self.type_class == ::Symbol
           value.to_sym
-        elsif self.type_class == Hash
-          {}.merge(value)
+        elsif self.type_class == ::Array
+          ::Array.new([*value])
+        elsif self.type_class == ::Hash
+          ::Hash.new.merge(value)
         else
           self.type_class.new(value, *self.rules[:args])
         end

--- a/test/unit/option_tests.rb
+++ b/test/unit/option_tests.rb
@@ -269,9 +269,17 @@ class NsOptions::Option
     subject{ @option }
 
     should "allow setting it with a array" do
-      new_value = [ :something, :else, :another ]
-      subject.value = new_value
-      assert_equal new_value, subject.value
+      expected = [ :something, :else, :another ]
+      subject.value = [ :something, :else, :another ]
+
+      assert_equal expected, subject.value
+    end
+
+    should "allow setting it with a single value" do
+      expected = [ :something ]
+      subject.value = :something
+
+      assert_equal expected, subject.value
     end
 
   end


### PR DESCRIPTION
This is more robust type-casting than the previous `Array.new(value)`
method.  Previously, if you set an Array option equal to some other
value, it would attempt to convert the value to an integer and then
build the array composed of that many nil values.  This default
`Array.new` behavior isn't very helpful or intuitive.

With this update, you can set a single value and the option will
type-cast the value to a single element array with the value. This
is a much more intuitive behavior.
