### PR TITLE
properly catch and handle coerce errors when writing opt vals on a ns

### DIFF
--- a/lib/ns-options/namespace_data.rb
+++ b/lib/ns-options/namespace_data.rb
@@ -131,11 +131,10 @@ module NsOptions
       elsif is_option_reader?(dslm)
         get_option(dslm.name)
       elsif is_option_writer?(dslm)
-        # TODO: remove same-named opt/ns when adding the other with same name
         add_option(dslm.name) unless has_option?(dslm.name)
         begin
           set_option(dslm.name, dslm.data)
-        rescue NsOptions::Option::CoerceError
+        rescue NsOptions::Option::CoerceError => err
           error! bt, err # reraise this exception with a sane backtrace
         end
       else # namespace writer or unknown

--- a/test/unit/namespace_tests.rb
+++ b/test/unit/namespace_tests.rb
@@ -44,7 +44,7 @@ class NsOptions::Namespace
   class OptionTests < BaseTests
     desc "when adding an option named `something`"
     setup do
-      @added_opt = @namespace.option('something', String, { :default => true })
+      @added_opt = @namespace.option('something', Fixnum, { :default => 1 })
     end
 
     should "have added an option to the namespace" do
@@ -52,8 +52,8 @@ class NsOptions::Namespace
 
       opt = subject.__data__.child_options[:something]
       assert_equal 'something',  opt.name
-      assert_equal String,  opt.type_class
-      assert_equal true, opt.rules[:default]
+      assert_equal Fixnum,  opt.type_class
+      assert_equal 1, opt.rules[:default]
     end
 
     should "return the option it added" do
@@ -86,13 +86,24 @@ class NsOptions::Namespace
     end
 
     should "be writable through the defined writer" do
-      assert_nothing_raised{ subject.something = "abc" }
-      assert_equal "abc", subject.something
+      assert_nothing_raised{ subject.something = 2 }
+      assert_equal 2, subject.something
     end
 
     should "be writable through the reader with args" do
-      assert_nothing_raised{ subject.something "123" }
-      assert_equal "123", subject.something
+      assert_nothing_raised{ subject.something 3 }
+      assert_equal 3, subject.something
+    end
+
+    should "raise CoerceError when writing values not coercable to the type class" do
+      err = begin
+        subject.something = "can't be coerced to a Fixnum!"
+      rescue Exception => err
+        err
+      end
+
+      assert_equal NsOptions::Option::CoerceError,  err.class
+      assert_included 'test/unit/namespace_tests.rb:', err.backtrace.first
     end
 
   end

--- a/test/unit/option_tests.rb
+++ b/test/unit/option_tests.rb
@@ -365,7 +365,7 @@ class NsOptions::Option
       @option = NsOptions::Option.new(:something, SuperSuperTestTest)
     end
 
-    should "reraise the arg error, with a custom message and backtrace" do
+    should "reraise as a CoerceError with a custom message and backtrace" do
       err = begin
         @option.value = "arg error should be raised"
       rescue Exception => err


### PR DESCRIPTION
Was missing the `=> err` to capture the rescued exception in a var.
This also showed there was no test coverage for this code so I made
sure and added a test.

Closes #68.
