### PR TITLE
clone default option values when saving

### DIFF
--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -52,7 +52,12 @@ module NsOptions
     end
 
     def reset
-      save_value(self.rules[:default])
+      default_value = begin
+        self.rules[:default].clone
+      rescue TypeError
+        self.rules[:default]
+      end
+      save_value(default_value)
     end
 
     def is_set?

--- a/test/unit/option_tests.rb
+++ b/test/unit/option_tests.rb
@@ -77,11 +77,11 @@ class NsOptions::Option
   class DefaultRuleTests < BaseTests
     desc "using the :default rule"
     setup do
-      @option = NsOptions::Option.new(:opt, Object, :default => "something")
+      @option = NsOptions::Option.new(:opt, Object, :default => {})
     end
 
     should "have defaulted value based on the rule" do
-      assert_equal 'something', subject.value
+      assert_equal Hash.new, subject.value
     end
 
     should "allow overwriting the default value" do
@@ -95,10 +95,13 @@ class NsOptions::Option
     end
 
     should "return the value to its default when `reset` is called" do
-      subject.value = "overwritten"
+      subject.value = {:hash => 'overwritten'}
       subject.reset
+      assert_equal Hash.new, subject.value
 
-      assert_equal 'something', subject.value
+      subject.value[:hash] = 'overwritten'
+      subject.reset
+      assert_equal Hash.new, subject.value
     end
 
   end


### PR DESCRIPTION
This is needed to ensure the `reset` method works properly.  If you
don't clone and edit the option values without setting them to a new
value, it edits the default directly.  This ensures defaults are always
cloned when resetting to ensure you get the original default value on
each reset.
