### PR TITLE
If `Namespace#to_hash` raises an exception, `inspect` still works

### DIFF
--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -60,7 +60,8 @@ module NsOptions
     end
 
     def inspect(*args)
-      "#<#{self.class}:#{'0x%x' % (self.object_id << 1)}:#{@__name__} #{to_hash.inspect}>"
+      inspect_details = to_hash.inspect rescue "error getting inspect details"
+      "#<#{self.class}:#{'0x%x' % (self.object_id << 1)}:#{@__name__} #{inspect_details}>"
     end
 
   end

--- a/test/unit/namespace_tests.rb
+++ b/test/unit/namespace_tests.rb
@@ -30,6 +30,14 @@ class NsOptions::Namespace
       assert_included subject.to_hash.inspect, subject.inspect
     end
 
+    should "still work if to_hash raises an exception" do
+      subject.option(:something, :default => proc{ raise 'test' })
+
+      output = nil
+      assert_nothing_raised{ output = subject.inspect }
+      assert_includes "error getting inspect details", output
+    end
+
     should "know its option type class" do
       assert_equal Object, subject.option_type_class
     end


### PR DESCRIPTION
When `Namespace#inspect` is called, it uses `to_hash` to build it's inspect
string. In certain situations, `to_hash` can throw exceptions which keeps the
namespace from being inspected. Furthermore, because `Namespace#inspect` is
called when we try to throw a `NoMethodError`, it can create an infinite loop
situation. These changes fix these problems by rescueing the `to_hash` usage
in `inspect`.
