### PR TITLE
Proxy related cleanups

### DIFF
--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -34,7 +34,7 @@ module NsOptions::Proxy
     end
 
     def inspect(*args, &block)
-      "#<#{super()}:#{__proxy_options__.__name__} #{__proxy_options__.to_hash.inspect}>"
+      "#<#{super()}:#{__proxy_options__.inspect}>"
     end
 
   end
@@ -52,7 +52,8 @@ module NsOptions::Proxy
     end
 
     def inspect(*args, &block)
-      "#<#{self.class.name}:#{'0x%x' % (self.object_id << 1)}:#{__proxy_options__.__name__} #{__proxy_options__.to_hash.inspect}>"
+      ref = "#{self.class.name}:#{'0x%x' % (self.object_id << 1)}"
+      "#<#{ref}:#{__proxy_options__.inspect}>"
     end
 
   end
@@ -65,7 +66,7 @@ module NsOptions::Proxy
     end
 
     def inspect(*args, &block)
-      "#<#{super()}:#{__proxy_options__.__name__} #{__proxy_options__.to_hash.inspect}>"
+      "#<#{super()}:#{__proxy_options__.inspect}>"
     end
 
   end

--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -33,6 +33,10 @@ module NsOptions::Proxy
       subclass.__proxy_options__.build_from(self.__proxy_options__)
     end
 
+    def inspect(*args, &block)
+      "#<#{super()}:#{__proxy_options__.__name__} #{__proxy_options__.to_hash.inspect}>"
+    end
+
   end
 
   module ClassReceiverIncludeMethods
@@ -47,6 +51,10 @@ module NsOptions::Proxy
       __proxy_options__ == other_proxy_instance.__proxy_options__
     end
 
+    def inspect(*args, &block)
+      "#<#{self.class.name}:#{'0x%x' % (self.object_id << 1)}:#{__proxy_options__.__name__} #{__proxy_options__.to_hash.inspect}>"
+    end
+
   end
 
   module ModuleReceiverExtendMethods
@@ -54,6 +62,10 @@ module NsOptions::Proxy
     # default initializer method
     def new(configs=nil)
       self.apply(configs || {})
+    end
+
+    def inspect(*args, &block)
+      "#<#{super()}:#{__proxy_options__.__name__} #{__proxy_options__.to_hash.inspect}>"
     end
 
   end

--- a/lib/ns-options/proxy.rb
+++ b/lib/ns-options/proxy.rb
@@ -30,7 +30,7 @@ module NsOptions::Proxy
 
     # This hook copies the proxy definition to any subclasses
     def inherited(subclass)
-      subclass.__proxy_options__.build_from(self.__proxy_options__)
+      subclass.build_from(self.__proxy_options__)
     end
 
     def inspect(*args, &block)
@@ -93,17 +93,15 @@ module NsOptions::Proxy
 
     def has_option?(*args, &block);    __proxy_options__.has_option?(*args, &block);    end
     def has_namespace?(*args, &block); __proxy_options__.has_namespace?(*args, &block); end
-    def required_set?(*args, &block);  __proxy_options__.required_set?(*args, &block);    end
-    def valid?(*args, &block);         __proxy_options__.valid?(*args, &block);           end
+    def required_set?(*args, &block);  __proxy_options__.required_set?(*args, &block);  end
+    def valid?(*args, &block);         __proxy_options__.valid?(*args, &block);         end
 
-    def apply(*args, &block);   __proxy_options__.apply(*args, &block);   end
-    def to_hash(*args, &block); __proxy_options__.to_hash(*args, &block); end
-    def each(*args, &block);    __proxy_options__.each(*args, &block);    end
-    def define(*args, &block);  __proxy_options__.define(*args, &block);  end
-
-    def inspect(*args, &block)
-      "#<#{self.class}:#{'0x%x' % (self.object_id << 1)}:#{__proxy_options__.__name__} #{__proxy_options__.to_hash.inspect}>"
-    end
+    def apply(*args, &block);      __proxy_options__.apply(*args, &block);      end
+    def to_hash(*args, &block);    __proxy_options__.to_hash(*args, &block);    end
+    def each(*args, &block);       __proxy_options__.each(*args, &block);       end
+    def define(*args, &block);     __proxy_options__.define(*args, &block);     end
+    def build_from(*args, &block); __proxy_options__.build_from(*args, &block); end
+    def reset(*args, &block);      __proxy_options__.reset(*args, &block);      end
 
     # for everything else, send to the proxied NAMESPACE handler
     # at this point it really just enables dynamic options writers

--- a/lib/ns-options/proxy_method.rb
+++ b/lib/ns-options/proxy_method.rb
@@ -45,8 +45,8 @@ module NsOptions
 
     def not_recommended_meth_names
       [ :option, :opt, :namespace, :ns,
-        :define, :inspect, :method_missing, :respond_to?,
-        :apply, :to_hash, :each, :required_set?, :valid?,
+        :inspect, :method_missing, :respond_to?, :required_set?, :valid?,
+        :define, :build_from, :reset, :apply, :to_hash, :each
       ]
     end
 

--- a/test/support/proxy.rb
+++ b/test/support/proxy.rb
@@ -10,8 +10,8 @@ module SomeProxy
       super(opts)
     end
 
-    opt :value1
-    opt :value2
+    opt :value1, String
+    opt :value2, Symbol
 
     ns :more do
       opt :other1
@@ -22,7 +22,7 @@ module SomeProxy
 
   class SomeOtherThing < SomeThing; end
 
-  opt :some, SomeThing, :default => { :value1 => 1 }
+  opt :some, SomeThing, :default => { :value1 => '1' }
   opt :some_prime, SomeThing, :default => { :value1 => 'one' }
   opt :stuff, :default => []
 

--- a/test/system/proxy_tests.rb
+++ b/test/system/proxy_tests.rb
@@ -13,7 +13,7 @@ class SomeProxyIntTests < Assert::Context
   subject { @proxy }
 
   should have_option :some, SomeProxy::SomeThing, {
-    :default => {:value1 => 1}
+    :default => {:value1 => '1'}
   }
 
   should have_option :some_prime, SomeProxy::SomeThing, {
@@ -35,7 +35,7 @@ class SomeProxySomeThingTests < SomeProxyIntTests
   should have_options :value1, :value2
 
   should "have its :value1 defaulted" do
-    assert_equal 1, subject.value1
+    assert_equal '1', subject.value1
   end
 
 end
@@ -49,5 +49,24 @@ class SomeProxySomeOtherThingTests < SomeProxyIntTests
   # should "have the same definition as its superclass"
   should have_namespace :more
   should have_options :value1, :value2
+
+  should "have the same definition as its superclass" do
+    # the superclass definition type casts :value1 to a String and :value2 to a Symbol
+    superprox = SomeProxy::SomeThing.new
+    assert_nil superprox.value1
+    assert_nil superprox.value2
+    superprox.value1 = :a_symbol
+    superprox.value2 = 'a_string'
+    assert_equal 'a_symbol', superprox.value1
+    assert_equal :a_string,  superprox.value2
+
+    # the subject (a subclass of the superclass) should do the same
+    assert_nil subject.value1
+    assert_nil subject.value2
+    subject.value1 = :a_symbol
+    subject.value2 = 'a_string'
+    assert_equal 'a_symbol', subject.value1
+    assert_equal :a_string,  subject.value2
+  end
 
 end

--- a/test/unit/proxy_tests.rb
+++ b/test/unit/proxy_tests.rb
@@ -188,6 +188,19 @@ module NsOptions::Proxy
       end
     end
 
+    should "should have its proxy namespace built on inheriting" do
+      super_ns = @a_super_class.instance_variable_get("@__proxy_options__")
+      assert_not_nil super_ns
+      assert_kind_of NsOptions::Namespace, super_ns
+
+      a_sub_class = Class.new(@a_super_class)
+      sub_ns = a_sub_class.instance_variable_get("@__proxy_options__")
+      assert_not_nil sub_ns
+      assert_kind_of NsOptions::Namespace, sub_ns
+
+      assert_not_same super_ns, sub_ns
+    end
+
     should "pass its definition to any subclass" do
       a_sub_class = Class.new(@a_super_class)
 

--- a/test/unit/proxy_tests.rb
+++ b/test/unit/proxy_tests.rb
@@ -23,6 +23,8 @@ module NsOptions::Proxy
           assert_respond_to :to_hash,           subject
           assert_respond_to :each,              subject
           assert_respond_to :define,            subject
+          assert_respond_to :build_from,        subject
+          assert_respond_to :reset,             subject
           assert_respond_to :inspect,           subject
           assert_respond_to :has_option?,       subject
           assert_respond_to :has_namespace?,    subject


### PR DESCRIPTION
- updated proxy inspect methods
- explicitly proxy the `build_from` and `reset` methods
- regression test for subclass proxies being built at inherited-time
