### PR TITLE
use distinct values when importing a hash with #apply and exporting a ha...

### DIFF
--- a/lib/ns-options.rb
+++ b/lib/ns-options.rb
@@ -8,6 +8,14 @@ module NsOptions
     receiver.class_eval { extend NsOptions::DSL }
   end
 
+  def self.distinct_value(value)
+    begin
+      value.clone
+    rescue TypeError
+      value
+    end
+  end
+
   module DSL
 
     # This is the main DSL method for creating a namespace of options for your

--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -52,12 +52,7 @@ module NsOptions
     end
 
     def reset
-      default_value = begin
-        self.rules[:default].clone
-      rescue TypeError
-        self.rules[:default]
-      end
-      save_value(default_value)
+      save_value NsOptions.distinct_value(self.rules[:default])
     end
 
     def is_set?


### PR DESCRIPTION
...sh with #to_hash

This adds value cloning to those methods and ensures that distinct
values will always be imported or exported when usingn #apply or
shared objects.
