### PR TITLE
Fix for setting a proc on a `returned_value` option type

### DIFF
--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -38,13 +38,8 @@ module NsOptions
     # if reading a lazy_proc, call the proc and return its coerced return val
     # otherwise, just return the stored value
     def value
-      if self.lazy_proc?(@value)
-        self.coerce(@value.call)
-      elsif @value.respond_to?(:returned_value)
-        @value.returned_value
-      else
-        @value
-      end
+      val = self.lazy_proc?(@value) ? self.coerce(@value.call) : @value
+      val.respond_to?(:returned_value) ? val.returned_value : val
     end
 
     def value=(new_value)

--- a/test/unit/option_tests.rb
+++ b/test/unit/option_tests.rb
@@ -520,6 +520,9 @@ class NsOptions::Option
     should "should honor `returned_value` when returning option values" do
       @hosted_at.value = "path/to/resource/"
       assert_equal '/path/to/resource', @hosted_at.value
+
+      @hosted_at.value = proc{ "path/to/resource/" }
+      assert_equal '/path/to/resource', @hosted_at.value
     end
 
   end


### PR DESCRIPTION
This fixes an edge case when a option with a type that defines a
`returned_value` method (like `NsOptions::Boolean`) is set with
a proc. It wasn't using the `returned_value` method so it would
return an instance of the class instead of the return value of
the `returned_value` method. This makes sure that even if a proc
is used, it will try to use `returned_value`.
