### PR TITLE
bugfix: macro was not setting `called_from` in its tests

### DIFF
--- a/lib/ns-options/assert_macros.rb
+++ b/lib/ns-options/assert_macros.rb
@@ -49,7 +49,7 @@ module NsOptions::AssertMacros
 
       Assert::Macro.new(test_name) do
 
-        should test_name do
+        should test_name, called_from do
 
           # have assertions
           assert subject.has_option?(opt_name)


### PR DESCRIPTION
This fixes a case where the `have_option` macro was not setting its
called from backtrace properly so any results produced by the macro
would not have the correct backtrace.

@jcredding ready for review (ran across this while testing assert).
