### PR TITLE
only raise coerce errors on `StandardErrors`

### DIFF
--- a/lib/ns-options/option.rb
+++ b/lib/ns-options/option.rb
@@ -99,7 +99,7 @@ module NsOptions
         else
           self.type_class.new(value, *self.rules[:args])
         end
-      rescue Exception => err
+      rescue StandardError => err
         raise CoerceError.new(self.type_class, value, err)
       end
     end

--- a/test/unit/namespace_tests.rb
+++ b/test/unit/namespace_tests.rb
@@ -114,6 +114,16 @@ class NsOptions::Namespace
       assert_included 'test/unit/namespace_tests.rb:', err.backtrace.first
     end
 
+    should "only raise CeorceError when StandardExceptions are raised writing values" do
+      subject.option('symbol', Symbol)
+
+      std_err_class = Class.new{ def to_sym; raise StandardError; end }
+      sig_err_class = Class.new{ def to_sym; raise SignalException, 'INT'; end }
+
+      assert_raises(NsOptions::Option::CoerceError){ subject.symbol = std_err_class.new }
+      assert_raises(SignalException){ subject.symbol = sig_err_class.new }
+    end
+
   end
 
   class NamespaceTests < BaseTests


### PR DESCRIPTION
This switches the option coercion handling to only raise a coercion
error if a`StandardError` occurs when writing values.

This is so non-standard errors (link `Interrupt` etc) that occur
while coercing values behave as expected.

@jcredding ready for review.
