### PR TITLE
Modify `Namespace` method missing, only use `caller` when error

### DIFF
--- a/lib/ns-options/namespace.rb
+++ b/lib/ns-options/namespace.rb
@@ -48,7 +48,10 @@ module NsOptions
     end
 
     def method_missing(meth, *args, &block)
-      @__data__.ns_method_missing(caller, meth, *args, &block)
+      @__data__.ns_method_missing(meth, *args, &block)
+    rescue StandardError => exception
+      exception.set_backtrace(caller)
+      raise exception
     end
 
     def ==(other_ns)

--- a/lib/ns-options/namespace_data.rb
+++ b/lib/ns-options/namespace_data.rb
@@ -129,7 +129,7 @@ module NsOptions
       false
     end
 
-    def ns_method_missing(bt, meth, *args, &block)
+    def ns_method_missing(meth, *args, &block)
       dslm = DslMethod.new(meth, *args, &block)
 
       if is_namespace_reader?(dslm)
@@ -138,14 +138,9 @@ module NsOptions
         get_option(dslm.name)
       elsif is_option_writer?(dslm)
         add_option(dslm.name) unless has_option?(dslm.name)
-        begin
-          set_option(dslm.name, dslm.data)
-        rescue NsOptions::Option::CoerceError => err
-          error! bt, err # reraise this exception with a sane backtrace
-        end
+        set_option(dslm.name, dslm.data)
       else # namespace writer or unknown
-        # raise a no meth err with a sane backtrace
-        error! bt, NoMethodError.new("undefined method `#{meth}' for #{@ns.inspect}")
+        raise NoMethodError.new("undefined method `#{meth}' for #{@ns.inspect}")
       end
     end
 
@@ -161,10 +156,6 @@ module NsOptions
 
     def is_option_writer?(dsl_method)
       !has_namespace?(dsl_method.name) && dsl_method.has_args?
-    end
-
-    def error!(backtrace, exception)
-      exception.set_backtrace(backtrace); raise exception
     end
 
   end


### PR DESCRIPTION
This changes the namespace's method missing to only call the
`caller` when an exception occurs. This is more efficient and
speeds up all access to reading/writing namespace options. This
is an internal change so no tests had to be modified. There are
already tests that ensure the behavior for raising no method
errors and setting the backtrace to the caller is still working.

Closes #82
